### PR TITLE
feat(web): phase 0-c route wiring for mountain race flow

### DIFF
--- a/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
+++ b/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
@@ -1,0 +1,10 @@
+import { InGameOverlaySlot, RaceSceneSlot } from "@/features/mountain-race/components";
+
+export function RaceRouteComposition() {
+  return (
+    <main className="route-shell">
+      <RaceSceneSlot />
+      <InGameOverlaySlot />
+    </main>
+  );
+}

--- a/apps/web/src/features/mountain-race/app/index.ts
+++ b/apps/web/src/features/mountain-race/app/index.ts
@@ -1,1 +1,7 @@
-export {};
+export { RaceRouteComposition } from "./RaceRouteComposition";
+export {
+  markResultReady,
+  markSetupComplete,
+  readRouteGuardSnapshot,
+  resetRouteGuardSnapshot,
+} from "./routeGuardState";

--- a/apps/web/src/features/mountain-race/app/routeGuardState.ts
+++ b/apps/web/src/features/mountain-race/app/routeGuardState.ts
@@ -1,0 +1,68 @@
+export type RouteGuardSnapshot = {
+  setupComplete: boolean;
+  hasResult: boolean;
+};
+
+const ROUTE_GUARD_STORAGE_KEY = "mountain-race-route-guards-v1";
+
+const DEFAULT_GUARD_SNAPSHOT: RouteGuardSnapshot = {
+  setupComplete: false,
+  hasResult: false,
+};
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+export function readRouteGuardSnapshot(): RouteGuardSnapshot {
+  if (!isBrowser()) {
+    return DEFAULT_GUARD_SNAPSHOT;
+  }
+
+  const rawValue = window.sessionStorage.getItem(ROUTE_GUARD_STORAGE_KEY);
+
+  if (!rawValue) {
+    return DEFAULT_GUARD_SNAPSHOT;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<RouteGuardSnapshot>;
+
+    return {
+      setupComplete: Boolean(parsed.setupComplete),
+      hasResult: Boolean(parsed.hasResult),
+    };
+  } catch {
+    return DEFAULT_GUARD_SNAPSHOT;
+  }
+}
+
+export function writeRouteGuardSnapshot(nextValue: Partial<RouteGuardSnapshot>) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const currentValue = readRouteGuardSnapshot();
+  const mergedValue: RouteGuardSnapshot = {
+    ...currentValue,
+    ...nextValue,
+  };
+
+  window.sessionStorage.setItem(ROUTE_GUARD_STORAGE_KEY, JSON.stringify(mergedValue));
+}
+
+export function markSetupComplete() {
+  writeRouteGuardSnapshot({ setupComplete: true, hasResult: false });
+}
+
+export function markResultReady() {
+  writeRouteGuardSnapshot({ hasResult: true });
+}
+
+export function resetRouteGuardSnapshot() {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(ROUTE_GUARD_STORAGE_KEY);
+}

--- a/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
+++ b/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@tanstack/react-router";
+import { markResultReady } from "@/features/mountain-race/app";
+
+export function InGameOverlaySlot() {
+  return (
+    <aside className="route-view" aria-label="In-game overlay slot">
+      <h2>In-Game Overlay</h2>
+      <p>HUD, event alert, and race log UI from gameplay owner will be mounted here.</p>
+      <p>
+        When race finishes, move to{" "}
+        <Link
+          to="/result"
+          onClick={() => {
+            markResultReady();
+          }}
+        >
+          /result
+        </Link>
+        .
+      </p>
+    </aside>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/RaceSceneSlot.tsx
+++ b/apps/web/src/features/mountain-race/components/RaceSceneSlot.tsx
@@ -1,0 +1,9 @@
+import { RaceScreen } from "@/features/mountain-race/screens";
+
+export function RaceSceneSlot() {
+  return (
+    <section className="route-view" aria-label="Race scene slot">
+      <RaceScreen />
+    </section>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/index.ts
+++ b/apps/web/src/features/mountain-race/components/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { InGameOverlaySlot } from "./InGameOverlaySlot";
+export { RaceSceneSlot } from "./RaceSceneSlot";

--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { resetRouteGuardSnapshot } from "@/features/mountain-race/app";
 
 export function ResultScreen() {
   return (
@@ -6,7 +7,16 @@ export function ResultScreen() {
       <h1>Result</h1>
       <p>Final board and replay actions will be shown here.</p>
       <p>
-        Return to <Link to="/">landing</Link>.
+        Return to{" "}
+        <Link
+          to="/"
+          onClick={() => {
+            resetRouteGuardSnapshot();
+          }}
+        >
+          landing
+        </Link>
+        .
       </p>
     </main>
   );

--- a/apps/web/src/features/mountain-race/screens/SetupScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/SetupScreen.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { markSetupComplete } from "@/features/mountain-race/app";
 
 export function SetupScreen() {
   return (
@@ -6,7 +7,16 @@ export function SetupScreen() {
       <h1>Setup</h1>
       <p>Configure player info and race params.</p>
       <p>
-        Proceed to <Link to="/race">/race</Link> when setup is ready.
+        Proceed to{" "}
+        <Link
+          to="/race"
+          onClick={() => {
+            markSetupComplete();
+          }}
+        >
+          /race
+        </Link>{" "}
+        when setup is ready.
       </p>
     </main>
   );

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { resetRouteGuardSnapshot } from "@/features/mountain-race";
 import { LandingScreen } from "@/features/mountain-race/screens";
 
 export const Route = createFileRoute("/")({
-  component: LandingScreen,
+  component: IndexRoute,
 });
+
+function IndexRoute() {
+  useEffect(() => {
+    // Entering landing resets the flow so the next setup/race cycle starts clean.
+    resetRouteGuardSnapshot();
+  }, []);
+
+  return <LandingScreen />;
+}

--- a/apps/web/src/routes/race.tsx
+++ b/apps/web/src/routes/race.tsx
@@ -1,6 +1,13 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { RaceScreen } from "@/features/mountain-race/screens";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { RaceRouteComposition, readRouteGuardSnapshot } from "@/features/mountain-race";
 
 export const Route = createFileRoute("/race")({
-  component: RaceScreen,
+  beforeLoad: () => {
+    const { setupComplete } = readRouteGuardSnapshot();
+
+    if (!setupComplete) {
+      throw redirect({ to: "/setup" });
+    }
+  },
+  component: RaceRouteComposition,
 });

--- a/apps/web/src/routes/result.tsx
+++ b/apps/web/src/routes/result.tsx
@@ -1,6 +1,18 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { readRouteGuardSnapshot } from "@/features/mountain-race";
 import { ResultScreen } from "@/features/mountain-race/screens";
 
 export const Route = createFileRoute("/result")({
+  beforeLoad: () => {
+    const { setupComplete, hasResult } = readRouteGuardSnapshot();
+
+    if (!setupComplete) {
+      throw redirect({ to: "/setup" });
+    }
+
+    if (!hasResult) {
+      throw redirect({ to: "/race" });
+    }
+  },
   component: ResultScreen,
 });


### PR DESCRIPTION
## Summary
- Wire `/`, `/setup`, `/race`, `/result` routes so the flow ownership is explicit at route level.
- Add route guards for `/race` and `/result` based on `setupComplete` and `hasResult` state snapshot.
- Introduce `RaceRouteComposition` and scene/overlay slot components so Phase 1 integration can attach feature owners without reworking route files.

## Test plan
- [x] `pnpm --filter @mountain-race/web typecheck`
- [ ] Run app and verify `/race` redirects to `/setup` when setup is incomplete.
- [ ] Verify `/result` redirects to `/race` until result-ready state is set.
- [ ] Verify `index -> setup -> race -> result` navigation path remains intact.

Made with [Cursor](https://cursor.com)