### PR TITLE
feat(web): define core type contracts for gameplay state (Phase 0)

### DIFF
--- a/apps/web/src/features/mountain-race/types/index.ts
+++ b/apps/web/src/features/mountain-race/types/index.ts
@@ -1,1 +1,127 @@
-export {};
+// ---------------------------------------------------------------------------
+// Mountain Race – Core Type Contracts
+// ---------------------------------------------------------------------------
+
+// ── Color ──────────────────────────────────────────────────────────────────
+
+export interface ColorPreset {
+  jacket: string;
+  inner: string;
+  pants: string;
+  buff: string;
+}
+
+// ── Character ──────────────────────────────────────────────────────────────
+
+export type CharacterStatus = "running" | "stunned" | "boosted" | "slowed" | "sliding";
+
+export interface CharacterStats {
+  hitCount: number;
+  setbackTotal: number;
+  ultimateUsed: number;
+  rankChanges: number;
+}
+
+export interface Character {
+  id: string;
+  name: string;
+  color: ColorPreset;
+  faceImage: string | null;
+  progress: number;
+  speed: number;
+  baseSpeed: number;
+  status: CharacterStatus;
+  stunEndTime: number;
+  stats: CharacterStats;
+}
+
+// ── Event Types ────────────────────────────────────────────────────────────
+
+export type SkillType = "booster" | "ankle_grab" | "trap" | "trip" | "wind_ride";
+
+export type UltimateType = "boulder" | "landslide" | "ice" | "helicopter" | "bear";
+
+export type GlobalEventType = "rain" | "fog" | "volcanic_ash" | "lightning";
+
+export type TargetEventType = "deer" | "rockfall" | "snake" | "pit";
+
+export type GameEventType = SkillType | UltimateType | GlobalEventType | TargetEventType;
+
+export type EventCategory = "skill" | "ultimate" | "global" | "target";
+
+export interface GameEvent {
+  id: string;
+  type: GameEventType;
+  category: EventCategory;
+  casterId?: string;
+  targetIds: string[];
+  timestamp: number;
+  duration: number;
+}
+
+// ── Event Log ──────────────────────────────────────────────────────────────
+
+export interface EventLog {
+  id: string;
+  text: string;
+  timestamp: number;
+}
+
+// ── Camera ─────────────────────────────────────────────────────────────────
+
+export type CameraMode = "follow" | "event_zoom" | "slowmo" | "shake" | "finish";
+
+// ── Speech Bubble ──────────────────────────────────────────────────────────
+
+export interface ActiveBubble {
+  characterId: string;
+  text: string;
+  endTime: number;
+}
+
+// ── Game State (store shape contract) ──────────────────────────────────────
+
+export interface GameState {
+  // ── Setup ────────────────────────────────────────────────────────────────
+  characters: Character[];
+  setupComplete: boolean;
+  hasResult: boolean;
+
+  addCharacter: () => void;
+  removeCharacter: (id: string) => void;
+  updateCharacter: (id: string, partial: Partial<Character>) => void;
+  finalizeSetup: () => void;
+
+  // ── Race lifecycle ───────────────────────────────────────────────────────
+  isRacing: boolean;
+  isPaused: boolean;
+  countdown: number;
+  elapsedTime: number;
+
+  startRace: () => void;
+  finishRace: () => void;
+  resetGame: () => void;
+  tick: (deltaTime: number) => void;
+
+  // ── Rankings ─────────────────────────────────────────────────────────────
+  rankings: string[];
+  finishedIds: string[];
+
+  // ── Events ───────────────────────────────────────────────────────────────
+  events: GameEvent[];
+  activeGlobalEvent: GlobalEventType | null;
+  globalEventEndTime: number;
+  ultimateCount: number;
+  pushEvent: (event: GameEvent) => void;
+
+  // ── Event logs ───────────────────────────────────────────────────────────
+  eventLogs: EventLog[];
+  pushLog: (log: EventLog) => void;
+
+  // ── Dialogue ─────────────────────────────────────────────────────────────
+  activeBubble: ActiveBubble | null;
+
+  // ── Camera ───────────────────────────────────────────────────────────────
+  cameraMode: CameraMode;
+  cameraTarget: string | null;
+}


### PR DESCRIPTION
## 요약

- 인게임 상태·액션의 타입 계약(Phase 0)을 확정하여 4인 병렬 개발의 기반을 고정한다.

## 변경 사항

- `apps/web/src/features/mountain-race/types/index.ts`에 다음 계약을 정의:
  - `Character`, `CharacterStatus`, `CharacterStats`, `ColorPreset` — 캐릭터 상태 모델
  - `SkillType`, `UltimateType`, `GlobalEventType`, `TargetEventType`, `GameEventType`, `EventCategory` — 이벤트 유형 union
  - `GameEvent`, `EventLog` — 이벤트·로그 데이터 구조
  - `CameraMode`, `ActiveBubble` — 카메라·말풍선 상태
  - `GameState` — Zustand store shape(state + action 계약)
- 박준형: `setupComplete`, `hasResult`, `startRace`, `finishRace`, `resetGame` 등 route guard 키 제공
- 윤영서: `characters[].progress/status/name/color/faceImage`, `rankings`, `cameraMode`, `cameraTarget`, `activeBubble`, `activeGlobalEvent`, `finishedIds` 키 제공
- 여찬규: `addCharacter`, `removeCharacter`, `updateCharacter`, `finalizeSetup`, `CharacterStats` 제공

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (pre-push hook에서 lint + format:check + typecheck + build 전체 통과)
  - [x] `pnpm format`
- 수동 확인: 타입 정의만 추가했으므로 런타임 동작 변경 없음
- 실행하지 않은 검증과 이유: store 구현이 아직 없어 인게임 시나리오 수동 테스트는 Phase 1 이후 진행 예정

## 스크린샷 또는 데모

- 타입 정의만 추가한 변경이므로 UI 변경 없음

## 문서 반영

- [x] 문서 변경 없음
- 관련 문서: `docs/plans/jeong-doeun-plan.md` Phase 0 기준에 따라 구현

## 리스크와 후속 작업

- Phase 1(store 뼈대)에서 `GameState` shape를 Zustand store로 구현하면서 미세 조정이 필요할 수 있으나, 계약 변경 시 즉시 공유 원칙 준수 예정
- `finishedIds`, `activeGlobalEvent` 등 윤영서 소비 키가 통합 시 누락 없이 노출되는지 Phase 2 통합에서 재확인 필요

Made with [Cursor](https://cursor.com)