### PR TITLE
feat(web): add Track component with R3F type declaration

### DIFF
--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { CatmullRomCurve3, Vector3, DoubleSide } from "three";
+import { FINISH_LINE } from "@/features/mountain-race/constants";
+
+const TRACK_POINTS = [
+  new Vector3(0, 0, 0),
+  new Vector3(10, 5, -20),
+  new Vector3(-5, 15, -50),
+  new Vector3(8, 25, -80),
+  new Vector3(-3, 35, -110),
+  new Vector3(0, 40, -130),
+];
+
+const TUBE_RADIUS = 0.4;
+const TUBE_SEGMENTS = 128;
+const TUBE_RADIAL_SEGMENTS = 8;
+
+export const trackCurve = new CatmullRomCurve3(TRACK_POINTS, false, "catmullrom", 0.5);
+
+export const FINISH_LINE_PROGRESS = FINISH_LINE;
+
+export function getTrackPoint(progress: number): Vector3 {
+  return trackCurve.getPointAt(Math.min(Math.max(progress, 0), 1));
+}
+
+export function getTrackTangent(progress: number): Vector3 {
+  return trackCurve.getTangentAt(Math.min(Math.max(progress, 0), 1));
+}
+
+export function getFinishLinePosition(): Vector3 {
+  return trackCurve.getPointAt(FINISH_LINE_PROGRESS);
+}
+
+function FinishLine() {
+  const position = useMemo(() => getFinishLinePosition(), []);
+
+  return (
+    <group position={position}>
+      <mesh position={[1.5, 2.5, 0]}>
+        <boxGeometry args={[0.12, 5, 0.12]} />
+        <meshStandardMaterial color="#8b4513" />
+      </mesh>
+      <mesh position={[-1.5, 2.5, 0]}>
+        <boxGeometry args={[0.12, 5, 0.12]} />
+        <meshStandardMaterial color="#8b4513" />
+      </mesh>
+      <mesh position={[0, 5, 0]}>
+        <boxGeometry args={[3.2, 0.25, 0.1]} />
+        <meshStandardMaterial color="#ffd700" emissive="#ffa500" emissiveIntensity={0.4} />
+      </mesh>
+      <mesh rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[1.8, 0.06, 8, 32]} />
+        <meshStandardMaterial color="#ffd700" emissive="#ffa500" emissiveIntensity={0.3} />
+      </mesh>
+    </group>
+  );
+}
+
+export function Track() {
+  const tubeArgs = useMemo(
+    () => [trackCurve, TUBE_SEGMENTS, TUBE_RADIUS, TUBE_RADIAL_SEGMENTS, false] as const,
+    [],
+  );
+
+  return (
+    <group>
+      <mesh>
+        <tubeGeometry args={[...tubeArgs]} />
+        <meshStandardMaterial color="#8B7355" roughness={0.9} side={DoubleSide} />
+      </mesh>
+      <FinishLine />
+    </group>
+  );
+}

--- a/apps/web/src/r3f-jsx.d.ts
+++ b/apps/web/src/r3f-jsx.d.ts
@@ -1,0 +1,1 @@
+import "@react-three/fiber";


### PR DESCRIPTION
- Implement Track with CatmullRomCurve3 and TubeGeometry visualization
- Export trackCurve, getTrackPoint, getTrackTangent for shared sampling
- Add finish line anchor with golden arch at FINISH_LINE progress
- Add R3F global type declaration to ensure CI typecheck passes

Made-with: Cursor

<!--
이 템플릿은 Mountain Race Workspace 기준으로 작성한다.

- diff와 검증 결과에서 확인한 사실만 적는다.
- 비어 있는 섹션은 지우지 말고 `없음` 또는 이유를 적는다.
- UI 변경이면 스크린샷이나 짧은 영상 링크를 남긴다.
- 검증은 실제로 실행한 명령과 수동 확인만 적는다.
- 미실행 검증은 숨기지 말고 이유를 적는다.
-->

## 요약

-

## 변경 사항

-

## 영향 범위

- [ ] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [ ] `pnpm lint`
  - [ ] `pnpm typecheck`
  - [ ] `pnpm check`
  - [ ] 기타:
- 수동 확인: 없음
- 실행하지 않은 검증과 이유: 없음

## 스크린샷 또는 데모

-

## 문서 반영

- [ ] 문서 변경 없음
- [ ] 관련 문서를 함께 수정함
- [ ] 후속 문서 반영 필요
- 관련 문서: 없음

## 리스크와 후속 작업

-
