### PR TITLE
feat(web): Phase 4 - CameraSystem 모드 전환 구현

### DIFF
--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -23,12 +23,24 @@ export function getTrackPoint(progress: number): Vector3 {
   return trackCurve.getPointAt(Math.min(Math.max(progress, 0), 1));
 }
 
+export function getTrackPointTo(progress: number, out: Vector3): Vector3 {
+  return trackCurve.getPointAt(Math.min(Math.max(progress, 0), 1), out);
+}
+
 export function getTrackTangent(progress: number): Vector3 {
   return trackCurve.getTangentAt(Math.min(Math.max(progress, 0), 1));
 }
 
+export function getTrackTangentTo(progress: number, out: Vector3): Vector3 {
+  return trackCurve.getTangentAt(Math.min(Math.max(progress, 0), 1), out);
+}
+
 export function getFinishLinePosition(): Vector3 {
   return trackCurve.getPointAt(FINISH_LINE_PROGRESS);
+}
+
+export function getFinishLinePositionTo(out: Vector3): Vector3 {
+  return trackCurve.getPointAt(FINISH_LINE_PROGRESS, out);
 }
 
 function FinishLine() {

--- a/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
+++ b/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
@@ -2,12 +2,15 @@ import { useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { Vector3 } from "three";
 import type { Character, CameraMode } from "@/features/mountain-race/types";
-import { getTrackPoint, getTrackTangent, getFinishLinePosition } from "../components/Track";
+import { getTrackPointTo, getTrackTangentTo, getFinishLinePositionTo } from "../components/Track";
 
 const _desired = new Vector3();
 const _lookTarget = new Vector3();
 const _behind = new Vector3();
 const _side = new Vector3();
+const _pos = new Vector3();
+const _tangent = new Vector3();
+const _finishPos = new Vector3();
 
 interface ModeConfig {
   height: number;
@@ -26,6 +29,7 @@ const MODE_CONFIG: Record<CameraMode, ModeConfig> = {
 
 const LERP_BASE = 0.04;
 const LERP_TRANSITION = 0.08;
+const TRANSITION_DURATION_MS = 250;
 const SHAKE_INTENSITY = 0.25;
 const SHAKE_DECAY = 0.9;
 
@@ -46,38 +50,44 @@ export function CameraSystem({
   const smoothLookAt = useRef(new Vector3(0, 5, -10));
   const prevMode = useRef<CameraMode>("follow");
   const shakeAmount = useRef(0);
+  const transitionStart = useRef(Number.NEGATIVE_INFINITY);
 
   useFrame(() => {
+    if (cameraMode !== prevMode.current) {
+      transitionStart.current = performance.now();
+      prevMode.current = cameraMode;
+    }
+
     const cfg = MODE_CONFIG[cameraMode];
 
     if (cameraMode === "finish") {
-      const finishPos = getFinishLinePosition();
-      _desired.set(finishPos.x + cfg.side, finishPos.y + cfg.height, finishPos.z + cfg.distance);
-      _lookTarget.copy(finishPos);
+      getFinishLinePositionTo(_finishPos);
+      _desired.set(_finishPos.x + cfg.side, _finishPos.y + cfg.height, _finishPos.z + cfg.distance);
+      _lookTarget.copy(_finishPos);
     } else {
       const target = resolveTarget(characters, rankings, cameraTarget);
       if (!target) return;
 
-      const pos = getTrackPoint(target.progress);
-      const tangent = getTrackTangent(target.progress);
+      getTrackPointTo(target.progress, _pos);
+      getTrackTangentTo(target.progress, _tangent);
 
-      _behind.copy(tangent).multiplyScalar(-cfg.distance);
-      _desired.copy(pos).add(_behind);
+      _behind.copy(_tangent).multiplyScalar(-cfg.distance);
+      _desired.copy(_pos).add(_behind);
       _desired.y += cfg.height;
 
       if (cfg.side !== 0) {
-        _side.set(-tangent.z, 0, tangent.x).normalize().multiplyScalar(cfg.side);
+        _side.set(-_tangent.z, 0, _tangent.x).normalize().multiplyScalar(cfg.side);
         _desired.add(_side);
       }
 
-      _lookTarget.copy(pos);
+      _lookTarget.copy(_pos);
       if (cfg.lookAhead > 0) {
-        _lookTarget.addScaledVector(tangent, cfg.lookAhead);
+        _lookTarget.addScaledVector(_tangent, cfg.lookAhead);
       }
     }
 
-    const transitioning = cameraMode !== prevMode.current;
-    const lerp = transitioning ? LERP_TRANSITION : LERP_BASE;
+    const inTransition = performance.now() - transitionStart.current < TRANSITION_DURATION_MS;
+    const lerp = inTransition ? LERP_TRANSITION : LERP_BASE;
 
     camera.position.lerp(_desired, lerp);
     smoothLookAt.current.lerp(_lookTarget, lerp);
@@ -95,7 +105,6 @@ export function CameraSystem({
     }
 
     camera.lookAt(smoothLookAt.current);
-    prevMode.current = cameraMode;
   });
 
   return null;
@@ -107,7 +116,8 @@ function resolveTarget(
   cameraTarget: string | null,
 ): Character | undefined {
   if (cameraTarget) {
-    return characters.find((c) => c.id === cameraTarget);
+    const found = characters.find((c) => c.id === cameraTarget);
+    if (found) return found;
   }
   const leaderId = rankings[0];
   if (leaderId) {

--- a/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
+++ b/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
@@ -1,0 +1,117 @@
+import { useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import { Vector3 } from "three";
+import type { Character, CameraMode } from "@/features/mountain-race/types";
+import { getTrackPoint, getTrackTangent, getFinishLinePosition } from "../components/Track";
+
+const _desired = new Vector3();
+const _lookTarget = new Vector3();
+const _behind = new Vector3();
+const _side = new Vector3();
+
+interface ModeConfig {
+  height: number;
+  distance: number;
+  side: number;
+  lookAhead: number;
+}
+
+const MODE_CONFIG: Record<CameraMode, ModeConfig> = {
+  follow: { height: 8, distance: 15, side: 0, lookAhead: 5 },
+  event_zoom: { height: 4, distance: 8, side: 4, lookAhead: 0 },
+  slowmo: { height: 6, distance: 12, side: 2, lookAhead: 3 },
+  finish: { height: 10, distance: 12, side: 5, lookAhead: 0 },
+  shake: { height: 8, distance: 15, side: 0, lookAhead: 5 },
+};
+
+const LERP_BASE = 0.04;
+const LERP_TRANSITION = 0.08;
+const SHAKE_INTENSITY = 0.25;
+const SHAKE_DECAY = 0.9;
+
+interface CameraSystemProps {
+  cameraMode: CameraMode;
+  cameraTarget: string | null;
+  characters: Character[];
+  rankings: string[];
+}
+
+export function CameraSystem({
+  cameraMode,
+  cameraTarget,
+  characters,
+  rankings,
+}: CameraSystemProps) {
+  const { camera } = useThree();
+  const smoothLookAt = useRef(new Vector3(0, 5, -10));
+  const prevMode = useRef<CameraMode>("follow");
+  const shakeAmount = useRef(0);
+
+  useFrame(() => {
+    const cfg = MODE_CONFIG[cameraMode];
+
+    if (cameraMode === "finish") {
+      const finishPos = getFinishLinePosition();
+      _desired.set(finishPos.x + cfg.side, finishPos.y + cfg.height, finishPos.z + cfg.distance);
+      _lookTarget.copy(finishPos);
+    } else {
+      const target = resolveTarget(characters, rankings, cameraTarget);
+      if (!target) return;
+
+      const pos = getTrackPoint(target.progress);
+      const tangent = getTrackTangent(target.progress);
+
+      _behind.copy(tangent).multiplyScalar(-cfg.distance);
+      _desired.copy(pos).add(_behind);
+      _desired.y += cfg.height;
+
+      if (cfg.side !== 0) {
+        _side.set(-tangent.z, 0, tangent.x).normalize().multiplyScalar(cfg.side);
+        _desired.add(_side);
+      }
+
+      _lookTarget.copy(pos);
+      if (cfg.lookAhead > 0) {
+        _lookTarget.addScaledVector(tangent, cfg.lookAhead);
+      }
+    }
+
+    const transitioning = cameraMode !== prevMode.current;
+    const lerp = transitioning ? LERP_TRANSITION : LERP_BASE;
+
+    camera.position.lerp(_desired, lerp);
+    smoothLookAt.current.lerp(_lookTarget, lerp);
+
+    if (cameraMode === "shake") {
+      shakeAmount.current = SHAKE_INTENSITY;
+    } else {
+      shakeAmount.current *= SHAKE_DECAY;
+    }
+
+    if (shakeAmount.current > 0.001) {
+      camera.position.x += (Math.random() - 0.5) * shakeAmount.current;
+      camera.position.y += (Math.random() - 0.5) * shakeAmount.current * 0.5;
+      camera.position.z += (Math.random() - 0.5) * shakeAmount.current;
+    }
+
+    camera.lookAt(smoothLookAt.current);
+    prevMode.current = cameraMode;
+  });
+
+  return null;
+}
+
+function resolveTarget(
+  characters: Character[],
+  rankings: string[],
+  cameraTarget: string | null,
+): Character | undefined {
+  if (cameraTarget) {
+    return characters.find((c) => c.id === cameraTarget);
+  }
+  const leaderId = rankings[0];
+  if (leaderId) {
+    return characters.find((c) => c.id === leaderId);
+  }
+  return characters[0];
+}

--- a/apps/web/src/features/mountain-race/systems/index.ts
+++ b/apps/web/src/features/mountain-race/systems/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { CameraSystem } from "./CameraSystem";


### PR DESCRIPTION
## Summary

- `systems/CameraSystem.tsx` 구현
  - **follow**: 리더 캐릭터를 track tangent 방향 기준 뒤쪽에서 추적. 높이 8, 거리 15
  - **event_zoom**: `cameraTarget` 캐릭터를 측면 클로즈업. 높이 4, 측면 오프셋 4
  - **finish**: finish line 앵커 지점으로 카메라 이동
  - **shake**: follow 베이스 + exponential decay 랜덤 오프셋 (강도 0.25, 감쇠율 0.9)
  - **slowmo**: follow 변형, 더 타이트한 프레이밍
- 모드 전환 시 lerp 속도 2배로 올려서 부드러운 easing 적용
- 모든 Vector3 모듈 스코프에 pre-allocate하여 per-frame GC 압력 제거
- `systems/index.ts`에서 `CameraSystem` re-export

## Context

`docs/plans/yoon-youngseo-plan.md` 기준 **Phase 4** 작업입니다.

## Test plan

- `cameraMode="follow"` 시 리더 캐릭터 뒤에서 자연스러운 추적
- `cameraMode="event_zoom"` + `cameraTarget` 설정 시 해당 캐릭터 클로즈업
- `cameraMode="finish"` 시 finish line으로 카메라 전환
- `cameraMode="shake"` 시 흔들림 발생, 모드 해제 후 점진적 감쇠
- 모드 간 전환 시 시야 점프/지터 없이 부드럽게 이동

Made with Cursor

Made with [Cursor](https://cursor.com)