### PR TITLE
feat(web): Phase 5 - RaceScreen scene 조합

### DIFF
--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -1,8 +1,51 @@
+import { Canvas } from "@react-three/fiber";
+import { useGameStore } from "@/features/mountain-race/store";
+import { Track } from "@/features/mountain-race/components/Track";
+import { Character } from "@/features/mountain-race/components/Character";
+import { Environment } from "@/features/mountain-race/components/Environment";
+import { SpeechBubble } from "@/features/mountain-race/components/SpeechBubble";
+import { CameraSystem } from "@/features/mountain-race/systems";
+
+function SceneContent() {
+  const characters = useGameStore((s) => s.characters);
+  const rankings = useGameStore((s) => s.rankings);
+  const finishedIds = useGameStore((s) => s.finishedIds);
+  const cameraMode = useGameStore((s) => s.cameraMode);
+  const cameraTarget = useGameStore((s) => s.cameraTarget);
+  const activeGlobalEvent = useGameStore((s) => s.activeGlobalEvent);
+  const activeBubble = useGameStore((s) => s.activeBubble);
+
+  const bubbleCharProgress = activeBubble
+    ? (characters.find((c) => c.id === activeBubble.characterId)?.progress ?? null)
+    : null;
+
+  return (
+    <>
+      <Track />
+      <Environment activeGlobalEvent={activeGlobalEvent} />
+      {characters.map((char) => (
+        <Character key={char.id} character={char} isFinished={finishedIds.includes(char.id)} />
+      ))}
+      <SpeechBubble activeBubble={activeBubble} characterProgress={bubbleCharProgress} />
+      <CameraSystem
+        cameraMode={cameraMode}
+        cameraTarget={cameraTarget}
+        characters={characters}
+        rankings={rankings}
+      />
+    </>
+  );
+}
+
 export function RaceScreen() {
   return (
-    <main className="route-shell route-view">
-      <h1>Race</h1>
-      <p>Race scene and in-game overlay will be composed here.</p>
+    <main className="route-shell route-view" style={{ position: "relative" }}>
+      <Canvas
+        camera={{ position: [0, 10, 20], fov: 60 }}
+        style={{ position: "absolute", inset: 0 }}
+      >
+        <SceneContent />
+      </Canvas>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- `screens/RaceScreen.tsx` placeholder를 실제 Canvas + scene graph로 교체
  - `SceneContent` 내부 컴포넌트에서 store 상태를 개별 selector로 구독
  - `Track`, `Environment`, `Character[]` map, `SpeechBubble`, `CameraSystem` 마운트
  - `activeBubble`의 캐릭터 progress를 조회하여 SpeechBubble에 전달
- HUD/EventLog/EventAlert는 포함하지 않음 (3D scene layer만 담당)
- Canvas는 부모 컨테이너를 채우도록 `position: absolute; inset: 0` 적용

## Context

`docs/plans/yoon-youngseo-plan.md` 기준 **Phase 5** 작업입니다.

## Test plan

- `/race` 경로 진입 시 3D 씬이 렌더링됨
- Track, Environment(지면/산/나무/구름), Character들이 모두 표시
- CameraSystem이 follow 모드로 리더 캐릭터를 추적
- activeBubble 존재 시 해당 캐릭터 위에 말풍선 표시
- `<RaceScreen />`만으로 독립적으로 동작

Made with Cursor

Made with [Cursor](https://cursor.com)