### PR TITLE
fix(web): Phase 6 - 통합 전 검증 수정

### DIFF
--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -43,7 +43,7 @@ export function RaceScreen() {
       className="route-shell"
       style={{
         position: "relative",
-        height: "100vh",
+        height: "100dvh",
         padding: 0,
         overflow: "hidden",
       }}

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -39,7 +39,15 @@ function SceneContent() {
 
 export function RaceScreen() {
   return (
-    <main className="route-shell route-view" style={{ position: "relative" }}>
+    <main
+      className="route-shell"
+      style={{
+        position: "relative",
+        height: "100vh",
+        padding: 0,
+        overflow: "hidden",
+      }}
+    >
       <Canvas
         camera={{ position: [0, 10, 20], fov: 60 }}
         style={{ position: "absolute", inset: 0 }}


### PR DESCRIPTION
## Summary

Phase 6 통합 전 검증 결과, 레이아웃 이슈 1건을 발견하여 수정합니다.

### 수정 사항

- **RaceScreen 풀스크린 레이아웃 수정**
  - `route-view` 클래스 제거 (불필요한 `display: grid` + `padding: 18px`)
  - `route-shell` 기본 패딩을 `0`으로 오버라이드
  - `height: 100vh` + `overflow: hidden`으로 Canvas가 전체 뷰포트를 채움
  - 기존에는 18px 패딩으로 인해 Canvas 주변에 배경 그라데이션 테두리가 보였음

### 검증 체크리스트

| 항목 | 상태 | 비고 |
|------|------|------|
| 2인 케이스 | ✅ | `MIN_PLAYERS=2`, Character map 정상 |
| 8인 케이스 | ✅ | `MAX_PLAYERS=8`, 각 캐릭터 고유 color/key |
| follow 카메라 | ✅ | 리더 추적, tangent 기반 뒤쪽 포지셔닝 |
| event_zoom 카메라 | ✅ | cameraTarget 측면 클로즈업 |
| finish 카메라 | ✅ | finish line 앵커로 이동 |
| shake 카메라 | ✅ | decay 오프셋, 모드 해제 후 감쇠 |
| 모드 전환 easing | ✅ | 250ms 윈도우 LERP_TRANSITION |
| fog 이벤트 | ✅ | 짙은 안개(10,60) ↔ 기본 헤이즈(40,200) 전환 |
| activeBubble 표시 | ✅ | 캐릭터 head anchor + billboard |
| Character status 연출 | ✅ | boosted/stunned/slowed/sliding emissive + tilt |
| 캐릭터 애니메이션 | ✅ | 팔/트레킹폴 swing, 걷기 바운스 |
| Track 좌표계 | ✅ | CatmullRomCurve3, out-param 헬퍼 |
| Finish line | ✅ | progress=FINISH_LINE 위치에 앵커 |
| 모듈 스코프 Vector3 | ✅ | CameraSystem 7개 pre-allocate |
| lint/typecheck/build | ✅ | 전체 통과 |
| 모바일 geometry 수 | ✅ | ~171 mesh (Track 5 + Env 54 + Char×8 112) |

### 씬 컴포넌트 완성 현황

| 컴포넌트 | 파일 | 상태 |
|----------|------|------|
| Track | `components/Track.tsx` | ✅ 완료 |
| Character | `components/Character.tsx` | ✅ 완료 |
| Environment | `components/Environment.tsx` | ✅ 완료 |
| SpeechBubble | `components/SpeechBubble.tsx` | ✅ 완료 |
| CameraSystem | `systems/CameraSystem.tsx` | ✅ 완료 |
| RaceScreen | `screens/RaceScreen.tsx` | ✅ 완료 |

`routes/race.tsx` 오너에게 바로 전달 가능한 상태입니다.

Made with Cursor

Made with [Cursor](https://cursor.com)