### PR TITLE
feat(web): Phase 4 - DialogueSystem 대사 스케줄링 구현

### DIFF
--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -9,6 +9,11 @@ import {
   MIN_PLAYERS,
   VOLCANIC_ASH_SPEED_MULT,
 } from "../constants/balance";
+import {
+  initDialogueScheduler,
+  processDialogues,
+  resetDialogueScheduler,
+} from "../systems/DialogueSystem";
 import { initEventScheduler, processEvents, resetEventScheduler } from "../systems/EventSystem";
 import type {
   ActiveBubble,
@@ -181,6 +186,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       stats: { hitCount: 0, setbackTotal: 0, ultimateUsed: 0, rankChanges: 0 },
     }));
     initEventScheduler(0);
+    initDialogueScheduler(0);
     set({
       isRacing: true,
       countdown: 0,
@@ -205,6 +211,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   resetGame: () => {
     idCounter = 0;
     resetEventScheduler();
+    resetDialogueScheduler();
     set(getInitialState());
   },
 
@@ -261,6 +268,16 @@ export const useGameStore = create<GameState>((set, get) => ({
     const finalCharacters = eventResult.characters;
     const finalRankings = computeRankings(finalCharacters);
 
+    // 5.5 Dialogue system
+    const dialogueResult = processDialogues({
+      characters: finalCharacters,
+      rankings: finalRankings,
+      finishedIds,
+      elapsedTime,
+      activeBubble: state.activeBubble,
+      newEvents: eventResult.newEvents,
+    });
+
     const isAllFinished = finishedIds.length === finalCharacters.length;
     set({
       characters: finalCharacters,
@@ -272,6 +289,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       activeGlobalEvent: eventResult.activeGlobalEvent,
       globalEventEndTime: eventResult.globalEventEndTime,
       ultimateCount: eventResult.ultimateCount,
+      activeBubble: dialogueResult.activeBubble,
       ...(isAllFinished ? { isRacing: false, hasResult: true } : {}),
     });
   },

--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -176,6 +176,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   // ── Race lifecycle ───────────────────────────────────────────────────────
 
   startRace: () => {
+    if (get().isRacing) return;
     const { characters } = get();
     const resetCharacters = characters.map((c) => ({
       ...c,
@@ -220,7 +221,10 @@ export const useGameStore = create<GameState>((set, get) => ({
     if (!state.isRacing || state.isPaused) return;
 
     const elapsedTime = state.elapsedTime + deltaTime;
-    const ashActive = state.activeGlobalEvent === "volcanic_ash";
+
+    const isGlobalEventActive =
+      state.activeGlobalEvent !== null && elapsedTime < state.globalEventEndTime;
+    const ashActive = isGlobalEventActive && state.activeGlobalEvent === "volcanic_ash";
 
     // 1. Status recovery + movement
     const movedCharacters = state.characters.map((c) => {

--- a/apps/web/src/features/mountain-race/systems/DialogueSystem.ts
+++ b/apps/web/src/features/mountain-race/systems/DialogueSystem.ts
@@ -1,0 +1,397 @@
+import type {
+  ActiveBubble,
+  Character,
+  GameEvent,
+  GameEventType,
+  GlobalEventType,
+  SkillType,
+  TargetEventType,
+  UltimateType,
+} from "../types";
+import {
+  DIALOGUE_DISPLAY_TIME_MS,
+  DIALOGUE_INTERVAL_MAX,
+  DIALOGUE_INTERVAL_MIN,
+  SLOWMO_PROGRESS_MIN,
+  SLOWMO_THRESHOLD,
+} from "../constants/balance";
+import {
+  CLOSE_RACE_DIALOGUES,
+  COMEBACK_DIALOGUES,
+  FIRST_PLACE_DIALOGUES,
+  GLOBAL_EVENT_DIALOGUES,
+  IDLE_DIALOGUES,
+  LAST_PLACE_DIALOGUES,
+  OVERTAKE_DIALOGUES,
+  OVERTAKEN_DIALOGUES,
+  SKILL_CASTER_DIALOGUES,
+  SKILL_VICTIM_DIALOGUES,
+  TARGET_EVENT_DIALOGUES,
+  ULTIMATE_FALLBACK_DIALOGUES,
+  ULTIMATE_SPECIFIC_DIALOGUES,
+} from "../data/dialogues";
+
+// ── Public interfaces ────────────────────────────────────────────────────────
+
+export interface DialogueTickInput {
+  characters: Character[];
+  rankings: string[];
+  finishedIds: string[];
+  elapsedTime: number;
+  activeBubble: ActiveBubble | null;
+  newEvents: GameEvent[];
+}
+
+export interface DialogueTickResult {
+  activeBubble: ActiveBubble | null;
+}
+
+// ── Module-level scheduler state ─────────────────────────────────────────────
+
+let nextDialogueAt = 0;
+let prevRankings: string[] = [];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function randomInRange(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function pickRandom<T>(arr: readonly T[]): T {
+  const item = arr[Math.floor(Math.random() * arr.length)];
+  if (item === undefined) throw new Error("pickRandom called on empty array");
+  return item;
+}
+
+function findChar(characters: readonly Character[], id: string): Character | undefined {
+  return characters.find((c) => c.id === id);
+}
+
+const DISPLAY_DURATION_SEC = DIALOGUE_DISPLAY_TIME_MS / 1000;
+
+function makeBubble(characterId: string, text: string, elapsedTime: number): ActiveBubble {
+  return { characterId, text, endTime: elapsedTime + DISPLAY_DURATION_SEC };
+}
+
+function advanceSchedule(elapsedTime: number): void {
+  nextDialogueAt = elapsedTime + randomInRange(DIALOGUE_INTERVAL_MIN, DIALOGUE_INTERVAL_MAX);
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const GOOD_SKILL_SET: ReadonlySet<GameEventType> = new Set<GameEventType>(["booster", "wind_ride"]);
+
+const COMEBACK_PREV_RANK_MIN = 3;
+
+const EVENT_CATEGORY_PRIORITY: Readonly<Record<string, number>> = {
+  ultimate: 0,
+  global: 1,
+  skill: 2,
+  target: 3,
+};
+
+// ── Event dialogue selection ─────────────────────────────────────────────────
+
+function pickEventDialogue(
+  events: readonly GameEvent[],
+  characters: readonly Character[],
+  finishedIds: string[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const sorted = [...events].sort(
+    (a, b) =>
+      (EVENT_CATEGORY_PRIORITY[a.category] ?? 3) - (EVENT_CATEGORY_PRIORITY[b.category] ?? 3),
+  );
+
+  for (const event of sorted) {
+    const bubble = pickDialogueForEvent(event, characters, finishedIds, elapsedTime);
+    if (bubble) return bubble;
+  }
+  return null;
+}
+
+function pickDialogueForEvent(
+  event: GameEvent,
+  characters: readonly Character[],
+  finishedIds: string[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  switch (event.category) {
+    case "ultimate":
+      return pickUltimateDialogue(event, characters, elapsedTime);
+    case "global":
+      return pickGlobalDialogue(event, characters, finishedIds, elapsedTime);
+    case "skill":
+      return pickSkillDialogue(event, characters, elapsedTime);
+    case "target":
+      return pickTargetDialogue(event, characters, elapsedTime);
+    default:
+      return null;
+  }
+}
+
+function pickUltimateDialogue(
+  event: GameEvent,
+  characters: readonly Character[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const ultimateType = event.type as UltimateType;
+  const specific = ULTIMATE_SPECIFIC_DIALOGUES[ultimateType];
+
+  if (specific?.victim.length && event.targetIds.length > 0) {
+    const victimId = pickRandom(event.targetIds);
+    const victim = findChar(characters, victimId);
+    if (victim) return makeBubble(victim.id, pickRandom(specific.victim), elapsedTime);
+  }
+
+  if (specific?.caster.length && event.casterId) {
+    const caster = findChar(characters, event.casterId);
+    if (caster) return makeBubble(caster.id, pickRandom(specific.caster), elapsedTime);
+  }
+
+  if (event.targetIds.length > 0) {
+    const victimId = pickRandom(event.targetIds);
+    const victim = findChar(characters, victimId);
+    if (victim) return makeBubble(victim.id, pickRandom(ULTIMATE_FALLBACK_DIALOGUES), elapsedTime);
+  }
+
+  return null;
+}
+
+function pickGlobalDialogue(
+  event: GameEvent,
+  characters: readonly Character[],
+  finishedIds: string[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const globalType = event.type as GlobalEventType;
+  const dialogues = GLOBAL_EVENT_DIALOGUES[globalType];
+  if (!dialogues || dialogues.length === 0) return null;
+
+  const eligible = characters.filter((c) => !finishedIds.includes(c.id));
+  if (eligible.length === 0) return null;
+
+  const speaker = pickRandom(eligible);
+  return makeBubble(speaker.id, pickRandom(dialogues), elapsedTime);
+}
+
+function pickSkillDialogue(
+  event: GameEvent,
+  characters: readonly Character[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const skillType = event.type as SkillType;
+
+  if (GOOD_SKILL_SET.has(event.type)) {
+    const pool = SKILL_CASTER_DIALOGUES[skillType];
+    if (pool.length > 0 && event.casterId) {
+      const caster = findChar(characters, event.casterId);
+      if (caster) return makeBubble(caster.id, pickRandom(pool), elapsedTime);
+    }
+    return null;
+  }
+
+  const victimPool: readonly string[] | undefined = SKILL_VICTIM_DIALOGUES[skillType];
+  if (victimPool && victimPool.length > 0 && event.targetIds.length > 0) {
+    const victimId = event.targetIds[0];
+    if (victimId !== undefined) {
+      const victim = findChar(characters, victimId);
+      if (victim) return makeBubble(victim.id, pickRandom(victimPool), elapsedTime);
+    }
+  }
+
+  const casterPool = SKILL_CASTER_DIALOGUES[skillType];
+  if (casterPool.length > 0 && event.casterId) {
+    const caster = findChar(characters, event.casterId);
+    if (caster) return makeBubble(caster.id, pickRandom(casterPool), elapsedTime);
+  }
+
+  return null;
+}
+
+function pickTargetDialogue(
+  event: GameEvent,
+  characters: readonly Character[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const targetType = event.type as TargetEventType;
+  const dialogues = TARGET_EVENT_DIALOGUES[targetType];
+  if (!dialogues || dialogues.length === 0 || event.targetIds.length === 0) return null;
+
+  const victimId = event.targetIds[0];
+  if (victimId === undefined) return null;
+
+  const victim = findChar(characters, victimId);
+  if (!victim) return null;
+
+  return makeBubble(victim.id, pickRandom(dialogues), elapsedTime);
+}
+
+// ── Situation dialogue selection ─────────────────────────────────────────────
+
+function pickSituationDialogue(
+  characters: readonly Character[],
+  rankings: string[],
+  finishedIds: string[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  if (prevRankings.length === 0) return null;
+
+  const activeRankings = rankings.filter((id) => !finishedIds.includes(id));
+  const activePrev = prevRankings.filter((id) => !finishedIds.includes(id));
+  if (activeRankings.length < 2) return null;
+
+  // 1. Comeback: was rank >= 3 (0-indexed) and now rank === 0
+  for (const id of activeRankings) {
+    const currentRank = activeRankings.indexOf(id);
+    const prevRank = activePrev.indexOf(id);
+    if (prevRank >= COMEBACK_PREV_RANK_MIN && currentRank === 0) {
+      const char = findChar(characters, id);
+      if (char) return makeBubble(char.id, pickRandom(COMEBACK_DIALOGUES), elapsedTime);
+    }
+  }
+
+  // 2. Overtake: rank improved (lower index = better rank)
+  for (const id of activeRankings) {
+    const currentRank = activeRankings.indexOf(id);
+    const prevRank = activePrev.indexOf(id);
+    if (prevRank === -1) continue;
+    if (currentRank < prevRank) {
+      const char = findChar(characters, id);
+      if (char) return makeBubble(char.id, pickRandom(OVERTAKE_DIALOGUES), elapsedTime);
+    }
+  }
+
+  // 3. Overtaken: rank dropped
+  for (const id of activeRankings) {
+    const currentRank = activeRankings.indexOf(id);
+    const prevRank = activePrev.indexOf(id);
+    if (prevRank === -1) continue;
+    if (currentRank > prevRank) {
+      const char = findChar(characters, id);
+      if (char) return makeBubble(char.id, pickRandom(OVERTAKEN_DIALOGUES), elapsedTime);
+    }
+  }
+
+  // 4. Close race: top-2 gap < threshold and leader past progress minimum
+  const firstId = activeRankings[0];
+  const secondId = activeRankings[1];
+  if (firstId !== undefined && secondId !== undefined) {
+    const first = findChar(characters, firstId);
+    const second = findChar(characters, secondId);
+    if (first && second) {
+      const gap = Math.abs(first.progress - second.progress);
+      if (gap < SLOWMO_THRESHOLD && first.progress > SLOWMO_PROGRESS_MIN) {
+        const speaker = pickRandom([first, second]);
+        return makeBubble(speaker.id, pickRandom(CLOSE_RACE_DIALOGUES), elapsedTime);
+      }
+    }
+  }
+
+  // 5. First place or last place (coin flip)
+  if (Math.random() < 0.5) {
+    const fId = activeRankings[0];
+    if (fId !== undefined) {
+      const char = findChar(characters, fId);
+      if (char) return makeBubble(char.id, pickRandom(FIRST_PLACE_DIALOGUES), elapsedTime);
+    }
+  } else {
+    const lId = activeRankings[activeRankings.length - 1];
+    if (lId !== undefined) {
+      const char = findChar(characters, lId);
+      if (char) return makeBubble(char.id, pickRandom(LAST_PLACE_DIALOGUES), elapsedTime);
+    }
+  }
+
+  return null;
+}
+
+// ── Idle dialogue selection ──────────────────────────────────────────────────
+
+function pickIdleDialogue(
+  characters: readonly Character[],
+  finishedIds: string[],
+  elapsedTime: number,
+): ActiveBubble | null {
+  const eligible = characters.filter((c) => !finishedIds.includes(c.id));
+  if (eligible.length === 0) return null;
+
+  const speaker = pickRandom(eligible);
+  return makeBubble(speaker.id, pickRandom(IDLE_DIALOGUES), elapsedTime);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export function initDialogueScheduler(startTime: number): void {
+  nextDialogueAt = startTime + randomInRange(DIALOGUE_INTERVAL_MIN, DIALOGUE_INTERVAL_MAX);
+  prevRankings = [];
+}
+
+export function resetDialogueScheduler(): void {
+  nextDialogueAt = 0;
+  prevRankings = [];
+}
+
+export function processDialogues(input: DialogueTickInput): DialogueTickResult {
+  const { characters, rankings, finishedIds, elapsedTime, activeBubble, newEvents } = input;
+
+  const result = resolveDialogue(
+    characters,
+    rankings,
+    finishedIds,
+    elapsedTime,
+    activeBubble,
+    newEvents,
+  );
+  prevRankings = rankings;
+  return result;
+}
+
+function resolveDialogue(
+  characters: readonly Character[],
+  rankings: string[],
+  finishedIds: string[],
+  elapsedTime: number,
+  activeBubble: ActiveBubble | null,
+  newEvents: readonly GameEvent[],
+): DialogueTickResult {
+  // 1. Try event dialogue first (may override existing bubble for high-priority)
+  if (newEvents.length > 0) {
+    const hasHighPriority = newEvents.some(
+      (e) => e.category === "ultimate" || e.category === "global",
+    );
+    const eventBubble = pickEventDialogue(newEvents, characters, finishedIds, elapsedTime);
+
+    if (eventBubble) {
+      if (hasHighPriority) {
+        return { activeBubble: eventBubble };
+      }
+      if (activeBubble === null || elapsedTime >= activeBubble.endTime) {
+        advanceSchedule(elapsedTime);
+        return { activeBubble: eventBubble };
+      }
+    }
+  }
+
+  // 2. Current bubble still valid — keep it
+  if (activeBubble !== null && elapsedTime < activeBubble.endTime) {
+    return { activeBubble };
+  }
+
+  // 3. Not yet time for a scheduled dialogue
+  if (elapsedTime < nextDialogueAt) {
+    return { activeBubble: null };
+  }
+
+  // 4. Try situation dialogue
+  const situationBubble = pickSituationDialogue(characters, rankings, finishedIds, elapsedTime);
+  if (situationBubble) {
+    advanceSchedule(elapsedTime);
+    return { activeBubble: situationBubble };
+  }
+
+  // 5. Fall back to idle dialogue
+  const idleBubble = pickIdleDialogue(characters, finishedIds, elapsedTime);
+  advanceSchedule(elapsedTime);
+  return { activeBubble: idleBubble };
+}

--- a/apps/web/src/features/mountain-race/systems/index.ts
+++ b/apps/web/src/features/mountain-race/systems/index.ts
@@ -1,3 +1,5 @@
 export { CameraSystem } from "./CameraSystem";
+export { initDialogueScheduler, processDialogues, resetDialogueScheduler } from "./DialogueSystem";
+export type { DialogueTickInput, DialogueTickResult } from "./DialogueSystem";
 export { initEventScheduler, processEvents, resetEventScheduler } from "./EventSystem";
 export type { EventTickInput, EventTickResult } from "./EventSystem";


### PR DESCRIPTION
## 요약

- Phase 4 DialogueSystem을 구현하여 idle / situation / event 우선순위 기반으로 캐릭터 말풍선(activeBubble)을 스케줄링한다.
- EventSystem과 동일한 모듈 레벨 스케줄러 패턴을 따르며, store의 tick 루프에 통합하여 매 프레임 대사를 결정한다.

## 변경 사항

### 신규 파일
- `systems/DialogueSystem.ts`: 대사 선택 시스템 전체 구현
  - `initDialogueScheduler` / `resetDialogueScheduler` (스케줄러 초기화/리셋)
  - `processDialogues` (매 tick 호출, activeBubble 결정)
  - 이벤트 대사: ultimate > global > skill/target 우선순위로 선택, 카테고리별 caster/victim 화자 분기
  - 상황 대사: comeback > overtake > overtaken > close race > first/last 우선순위
  - idle 대사: 스케줄 도달 시 랜덤 캐릭터 + 랜덤 대사
  - ultimate/global 이벤트 반응은 기존 버블을 덮어쓸 수 있음 (MVP 가이드 3.6)
  - prevRankings를 모듈 내부에서 관리하여 순위 변동 감지

### 수정 파일
- `systems/index.ts`: DialogueSystem 공개 API 재export
- `store/useGameStore.ts`: 3곳 수정
  - `startRace()`: `initDialogueScheduler(0)` 호출
  - `resetGame()`: `resetDialogueScheduler()` 호출
  - `tick()`: 이벤트 처리 후 `processDialogues()` 호출, `set()`에 activeBubble 반영

### 이전 커밋 (브랜치에 포함)
- Phase 3 EventSystem 구현 및 버그 수정
- RaceScreen 씬 그래프 통합
- race route 연결

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (lint + format:check + typecheck + build 전체 통과)
  - [x] 기타: pre-push hook이 `pnpm check`를 자동 실행하여 push 시점에도 검증됨
- 수동 확인: 없음 (런타임 레이스 실행 확인은 미실행)
- 실행하지 않은 검증과 이유: 브라우저에서 실제 레이스를 실행하여 말풍선 표시 타이밍과 우선순위를 확인하는 수동 테스트는 미실행. 이 PR은 시스템 로직만 추가하며, SpeechBubble 렌더링(윤영서 소유)과의 통합은 씬 연결 후 확인 필요.

## 스크린샷 또는 데모

- UI 변경 없음. DialogueSystem은 store의 activeBubble 값을 갱신하는 순수 로직이며, 시각적 렌더링은 SpeechBubble.tsx(윤영서 소유)가 담당한다.

## 문서 반영

- [x] 문서 변경 없음
- [ ] 관련 문서를 함께 수정함
- [ ] 후속 문서 반영 필요
- 관련 문서: `docs/plans/jeong-doeun-plan.md` Phase 4 완료 상태 업데이트는 후속으로 진행

## 리스크와 후속 작업

- prevRankings는 모듈 레벨 상태이므로 HMR 시 초기화되지 않을 수 있음. 개발 중 레이스를 재시작하면 해소됨.
- 대사 발동 빈도와 타이밍은 실제 레이스 플레이 후 밸런스 조정이 필요할 수 있음.
- Phase 5 (In-Game Overlay: HUD, EventAlert, EventLog)와 Phase 6 (Result용 데이터)이 후속 작업.

Made with [Cursor](https://cursor.com)