### PR TITLE
feat(web): Phase 2 — SetupScreen UX/접근성/비주얼 개선

### DIFF
--- a/apps/web/src/features/mountain-race/screens/SetupScene.tsx
+++ b/apps/web/src/features/mountain-race/screens/SetupScene.tsx
@@ -1,16 +1,29 @@
 import { useFrame } from "@react-three/fiber";
+import { useEffect, useState } from "react";
 import { Environment } from "@/features/mountain-race/components/Environment";
 import { Track } from "@/features/mountain-race/components/Track";
 
 function SetupCamera() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
   useFrame(({ camera, clock }) => {
-    const t = clock.elapsedTime * 0.03;
+    const speed = reduced ? 0 : 0.03;
+    const t = clock.elapsedTime * speed;
     const radius = 30;
     camera.position.x = Math.sin(t) * radius;
     camera.position.z = Math.cos(t) * radius - 35;
     camera.position.y = 25;
     camera.lookAt(0, 8, -35);
   });
+
   return null;
 }
 

--- a/apps/web/src/features/mountain-race/screens/SetupScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/SetupScreen.tsx
@@ -270,7 +270,7 @@ export function SetupScreen() {
                           type="button"
                           onClick={() => handleFaceRemove(character.id)}
                           className="self-start rounded px-1 py-0.5 text-[0.6rem] text-red-400/70 transition hover:bg-red-500/10 hover:text-red-400"
-                          aria-label="얼굴 이미지 삭제"
+                          aria-label={`${character.name.trim() || `산악인 ${index + 1}`} 얼굴 이미지 삭제`}
                         >
                           삭제
                         </button>


### PR DESCRIPTION
## Summary

SetupScreen의 UX, 접근성, 비주얼을 개선하고 LandingScreen과 디자인 시스템을 통일한다.

### 변경 내역 (8 commits)

| 커밋 | 유형 | 내용 |
|------|------|------|
| `79b907e` | feat | 얼굴 이미지 삭제 버튼 — `faceImage: null` 복원 |
| `a4ea556` | fix | 빈 닉네임 방어 — 시작 시 `산악인 N` 자동 적용 |
| `2c045c0` | style | 자켓 색상 좌측 스트라이프 + 뱃지 색상 동기화 |
| `493aedc` | style | 파티게임 톤 리디자인 — 중앙 브랜딩, emerald 뱃지 |
| `ec828b3` | a11y | 동적 aria-label, truncate, 터치 타겟 개선 |
| `6639bce` | feat | R3F 3D 산악 배경 추가 (SetupScene.tsx) |
| `f7e134c` | style | LandingScreen 디자인 시스템 통일 — 비네트, 다크 글래스모피즘, 흰색 CTA |
| `994463b` | style | 4열 그리드 + 인라인 액션 바 + 수직 위치 조정 |

### 디자인 일관성

LandingScreen과 동일한 시각 언어를 공유:
- 3겹 비네트/그라디언트 오버레이
- `border-white/20 bg-white/10 backdrop-blur-md` 뱃지/툴바
- 흰색 텍스트 + text-shadow 헤더
- 흰색 CTA + gradient hover + scale 트랜지션
- 다크 글래스모피즘 카드 (`bg-black/25 backdrop-blur-md`)

### 레이아웃

- 모바일: 2열 그리드
- 데스크톱(lg): 4열 그리드 — 8인 시 2행으로 수용
- 버튼: 카드 바로 아래 중앙 정렬, gap-3
- 콘텐츠: `pt-[12vh]`로 시각적 중심보다 살짝 위 배치

### 영향 범위

- **변경 파일**: `SetupScreen.tsx`, `SetupScene.tsx` (신규)
- store/types/routes 변경 없음 — 기존 계약 호출만 사용
- API / docs / CI / .cursor 변경 없음

### 검증

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm format:check` 통과
- [x] `pnpm build` 통과
- [x] `pnpm check` (pre-push hook) 통과
- [ ] 스크린샷/데모 영상 미첨부 (로컬 수동 확인 완료)

### 알려진 제약

- `styles.css`의 `.route-shell` 패딩 규칙은 이번 변경에서 더 이상 영향 없음 (inline style `padding: 0`으로 오버라이드)
- 8인 실기기 테스트는 미진행