### PR TITLE
feat(web): Phase 5 - In-Game Overlay (HUD, EventAlert, EventLog) 구현

### DIFF
--- a/apps/web/src/features/mountain-race/components/EventAlert.tsx
+++ b/apps/web/src/features/mountain-race/components/EventAlert.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from "react";
+import { useGameStore } from "../store/useGameStore";
+import {
+  formatMessage,
+  GLOBAL_EVENT_MESSAGES,
+  ULTIMATE_ANNOUNCE_MESSAGE,
+  ULTIMATE_MESSAGES,
+} from "../data/eventMessages";
+import type { GameEvent, GlobalEventType, UltimateType } from "../types";
+
+const ALERT_DISPLAY_MS = 2000;
+
+interface AlertInfo {
+  text: string;
+  eventId: string;
+}
+
+function buildAlertText(event: GameEvent, getName: (id: string) => string): string | null {
+  if (event.category === "ultimate" && event.type in ULTIMATE_MESSAGES) {
+    const casterName = event.casterId ? getName(event.casterId) : "???";
+    const announce = formatMessage(ULTIMATE_ANNOUNCE_MESSAGE, casterName);
+    const detail = ULTIMATE_MESSAGES[event.type as UltimateType];
+    return `${announce}\n${formatMessage(detail, casterName)}`;
+  }
+
+  if (event.category === "global" && event.type in GLOBAL_EVENT_MESSAGES) {
+    const messages = GLOBAL_EVENT_MESSAGES[event.type as GlobalEventType];
+    if (messages[0]) {
+      const targetName = event.targetIds[0] ? getName(event.targetIds[0]) : "";
+      return formatMessage(messages[0], targetName);
+    }
+  }
+
+  return null;
+}
+
+export function EventAlert() {
+  const events = useGameStore((s) => s.events);
+  const [alert, setAlert] = useState<AlertInfo | null>(null);
+  const prevCountRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (events.length <= prevCountRef.current) {
+      prevCountRef.current = events.length;
+      return;
+    }
+
+    const newEvents = events.slice(prevCountRef.current);
+    prevCountRef.current = events.length;
+
+    const alertEvent = newEvents.find((e) => e.category === "ultimate" || e.category === "global");
+    if (!alertEvent) return;
+
+    const { characters } = useGameStore.getState();
+    const getName = (id: string): string => characters.find((c) => c.id === id)?.name ?? "???";
+
+    const text = buildAlertText(alertEvent, getName);
+    if (!text) return;
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setAlert({ text, eventId: alertEvent.id });
+    timerRef.current = setTimeout(() => setAlert(null), ALERT_DISPLAY_MS);
+  }, [events]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  if (!alert) return null;
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div
+        key={alert.eventId}
+        className="animate-in fade-in-0 zoom-in-75 rounded-2xl bg-black/60 px-8 py-5 text-center backdrop-blur-md duration-300"
+      >
+        {alert.text.split("\n").map((line, i) => (
+          <p
+            key={`${alert.eventId}-${String(i)}`}
+            className={
+              i === 0
+                ? "text-2xl font-bold text-white md:text-3xl"
+                : "mt-2 text-lg font-bold text-white/90 md:text-xl"
+            }
+          >
+            {line}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/EventLog.tsx
+++ b/apps/web/src/features/mountain-race/components/EventLog.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { useGameStore } from "../store/useGameStore";
+
+const MAX_VISIBLE_LOGS = 8;
+
+export function EventLog() {
+  const eventLogs = useGameStore((s) => s.eventLogs);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const visibleLogs = eventLogs.slice(-MAX_VISIBLE_LOGS);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && eventLogs.length > 0) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [eventLogs]);
+
+  if (visibleLogs.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-16 left-3 w-72 max-w-[45vw] md:bottom-14">
+      <div
+        ref={scrollRef}
+        className="flex max-h-[35vh] flex-col gap-1 overflow-y-auto rounded-lg bg-black/40 p-2 backdrop-blur-sm"
+      >
+        {visibleLogs.map((log) => (
+          <p key={log.id} className="text-xs leading-relaxed text-white/90">
+            {log.text}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/HUD.tsx
+++ b/apps/web/src/features/mountain-race/components/HUD.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from "react";
+import { useGameStore } from "../store/useGameStore";
+import { FINISH_LINE } from "../constants/balance";
+import type { CharacterStatus } from "../types";
+
+const STATUS_INDICATORS: Partial<Record<CharacterStatus, string>> = {
+  stunned: "😵",
+  boosted: "🚀",
+  slowed: "🐌",
+  sliding: "🧊",
+};
+
+const MARKER_INSET_PX = 10;
+const SUMMIT_LABEL_RESERVED_PX = 56;
+
+export function HUD() {
+  const characters = useGameStore((s) => s.characters);
+  const rankings = useGameStore((s) => s.rankings);
+  const finishedIds = useGameStore((s) => s.finishedIds);
+  const activeGlobalEvent = useGameStore((s) => s.activeGlobalEvent);
+
+  const isFogActive = activeGlobalEvent === "fog";
+
+  const characterMap = useMemo(() => new Map(characters.map((c) => [c.id, c])), [characters]);
+
+  const finishedSet = useMemo(() => new Set(finishedIds), [finishedIds]);
+
+  return (
+    <>
+      {/* ── Ranking list — top right ─────────────────────────────────── */}
+      <div className="absolute top-3 right-3 flex max-h-[70vh] flex-col gap-1 overflow-y-auto">
+        {rankings.map((id, index) => {
+          const char = characterMap.get(id);
+          if (!char) return null;
+
+          const isFinished = finishedSet.has(id);
+          const isNameVisible = !isFogActive || index === 0 || isFinished;
+          const statusIcon = STATUS_INDICATORS[char.status];
+
+          return (
+            <div
+              key={id}
+              className="flex items-center gap-2 rounded-lg bg-black/50 px-3 py-1.5 text-sm text-white backdrop-blur-sm"
+            >
+              <span className="w-5 shrink-0 text-center font-bold text-amber-400">{index + 1}</span>
+              <span
+                className="h-3 w-3 shrink-0 rounded-full border border-white/40"
+                style={{ backgroundColor: char.color.jacket }}
+              />
+              <span className="min-w-0 max-w-28 truncate md:max-w-40">
+                {isFinished ? "✅ " : ""}
+                {isNameVisible ? char.name : "???"}
+              </span>
+              {statusIcon && <span className="shrink-0 text-xs">{statusIcon}</span>}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Progress bar — bottom ────────────────────────────────────── */}
+      <div className="absolute right-4 bottom-14 left-4 md:bottom-4">
+        <div className="relative h-7 rounded-full bg-black/40 backdrop-blur-sm">
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-white/80 select-none">
+            🏔️ 정상
+          </span>
+
+          {characters.map((char) => {
+            const ratio = Math.min(char.progress / FINISH_LINE, 1);
+            return (
+              <div
+                key={char.id}
+                className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 transition-[left] duration-150 ease-out"
+                style={{
+                  left: `clamp(${MARKER_INSET_PX}px, ${ratio * 100}%, calc(100% - ${SUMMIT_LABEL_RESERVED_PX}px))`,
+                }}
+                title={char.name}
+              >
+                <div
+                  className={`h-4 w-4 rounded-full border-2 border-white/70 shadow-sm ${
+                    finishedSet.has(char.id) ? "ring-2 ring-amber-400" : ""
+                  }`}
+                  style={{ backgroundColor: char.color.jacket }}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
+++ b/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
@@ -1,8 +1,19 @@
+import { useEffect } from "react";
+import { markResultReady } from "@/features/mountain-race/app";
+import { useGameStore } from "../store/useGameStore";
 import { HUD } from "./HUD";
 import { EventAlert } from "./EventAlert";
 import { EventLog } from "./EventLog";
 
 export function InGameOverlaySlot() {
+  const hasResult = useGameStore((s) => s.hasResult);
+
+  useEffect(() => {
+    if (hasResult) {
+      markResultReady();
+    }
+  }, [hasResult]);
+
   return (
     <aside className="pointer-events-none fixed inset-0 z-10" aria-label="In-game overlay">
       <HUD />

--- a/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
+++ b/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
@@ -1,23 +1,13 @@
-import { Link } from "@tanstack/react-router";
-import { markResultReady } from "@/features/mountain-race/app";
+import { HUD } from "./HUD";
+import { EventAlert } from "./EventAlert";
+import { EventLog } from "./EventLog";
 
 export function InGameOverlaySlot() {
   return (
-    <aside className="route-view" aria-label="In-game overlay slot">
-      <h2>In-Game Overlay</h2>
-      <p>HUD, event alert, and race log UI from gameplay owner will be mounted here.</p>
-      <p>
-        When race finishes, move to{" "}
-        <Link
-          to="/result"
-          onClick={() => {
-            markResultReady();
-          }}
-        >
-          /result
-        </Link>
-        .
-      </p>
+    <aside className="pointer-events-none fixed inset-0 z-10" aria-label="In-game overlay">
+      <HUD />
+      <EventAlert />
+      <EventLog />
     </aside>
   );
 }


### PR DESCRIPTION
## 요약

- Phase 5 In-Game Overlay 구현: 레이스 관전 시 3D 씬 위에 고정되는 HUD, EventAlert, EventLog 3개 컴포넌트 신규 생성 및 InGameOverlaySlot 플레이스홀더를 실제 오버레이 레이어로 교체

## 변경 사항

### 신규 파일

- **`components/HUD.tsx`**: 순위 리스트(우상단) + 진행률 바(하단)
  - 순위: `rankings` 순서대로 순위 번호 + 색상 아이콘 + 이름 표시
  - 안개 이벤트(`activeGlobalEvent === "fog"`) 시 1등 이외 이름을 `???`로 마스킹
  - 완주 캐릭터 체크마크 + 골드 링 표시
  - 상태 이모지 (😵 기절 / 🚀 부스터 / 🐌 감속 / 🧊 슬라이딩)
  - 진행률 바: 캐릭터 `color.jacket` 색상 마커가 `progress` 비율로 이동, 우측 끝 `🏔️ 정상` 라벨
  - `useMemo`로 `characterMap` / `finishedSet` 캐싱, 매직넘버 상수 추출

- **`components/EventAlert.tsx`**: 화면 중앙 대형 알림
  - `events` 배열 증분 감지로 새 `ultimate` / `global` 카테고리 이벤트 발견 시 알림
  - `eventMessages.ts`의 템플릿 + `formatMessage`로 텍스트 생성
  - 2초 표시 후 자동 소멸, `animate-in fade-in-0 zoom-in-75` 엔트런스 애니메이션
  - `useGameStore.getState()`로 characters를 임시 조회하여 불필요한 구독 방지
  - `in` 연산자로 이벤트 타입 키 존재 여부 런타임 확인 후 `as` 단언 사용

- **`components/EventLog.tsx`**: 이벤트 로그 피드
  - `eventLogs`에서 최근 8건만 표시 (좌측 하단 반투명 패널)
  - 새 로그 추가 시 자동 하단 스크롤

### 수정 파일

- **`components/InGameOverlaySlot.tsx`**: placeholder 텍스트 + `/result` 링크 제거 → `position: fixed; inset: 0; pointer-events: none; z-10` 오버레이 레이어로 변환, HUD/EventAlert/EventLog 마운트

### 변경 없음

- `components/index.ts`: barrel export는 기존 그대로 유지 (`EventLog` 타입명과 컴포넌트명 충돌 방지)

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (lint + format:check + typecheck + build)
  - [x] pre-push hook (`pnpm check`) 통과
- 수동 확인: 없음 — game loop(`tick`)가 아직 호출되지 않아 실제 레이스 중 오버레이 동작은 미확인
- 실행하지 않은 검증과 이유: 브라우저에서 실제 레이스 관전 흐름 확인 — `startRace` + `tick`을 호출하는 레이어가 아직 wiring되지 않아 인게임 상태를 시뮬레이션할 수 없음

## 스크린샷 또는 데모

UI가 3D 씬 위 오버레이이고, game loop가 미연결 상태이므로 스크린샷 없음. 오버레이가 실제로 동작하는 모습은 game loop wiring 후 확인 가능.

## 문서 반영

- [x] 문서 변경 없음
- [ ] 관련 문서를 함께 수정함
- [ ] 후속 문서 반영 필요
- 관련 문서: `docs/plans/jeong-doeun-plan.md`의 Phase 5 항목 — 완료 표시는 merge 후 별도 커밋 예정

## 리스크와 후속 작업

- **`/result` 전환 경로 제거**: 기존 InGameOverlaySlot의 `markResultReady()` + `/result` 링크를 제거했으므로, 현재 `/result`로 수동 전환할 수 있는 경로가 없음. store의 `hasResult: true` 상태 전환 + route guard redirect로 대체 예정이나, game loop wiring이 선행되어야 함.
- **game loop 미연결**: `startRace()` + `tick()`을 호출하는 컴포넌트/훅이 아직 없어, 오버레이 컴포넌트들이 실제 데이터를 받아 렌더링되는 상황을 검증하지 못함.
- **EventAlert `as` 타입 단언**: `GameEvent.type`이 discriminated union이 아닌 flat union이므로 category 체크 후에도 TypeScript가 type을 좁혀주지 못함. `in` 연산자로 런타임 안전성은 확보했으나, types 설계 개선이 근본 해결.
- **store `events` 배열 매 tick 새 참조**: `tick` 내부에서 `[...state.events, ...newEvents]`가 newEvents가 빈 배열이어도 새 참조를 생성하여, EventAlert가 매 tick 리렌더될 수 있음. store 측 최적화 필요.

Made with [Cursor](https://cursor.com)