### PR TITLE
feat(web): Phase 6 — finish ordering, grace period, per-character finishTime

### DIFF
--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -263,26 +263,28 @@ export const useGameStore = create<GameState>((set, get) => ({
 
       const ashMult = ashActive ? VOLCANIC_ASH_SPEED_MULT : 1;
       const jitter = 1 + (Math.random() - 0.5) * JITTER_RANGE;
-      const progress = Math.min(char.progress + char.speed * deltaTime * jitter * ashMult, 1);
+      const progress = char.progress + char.speed * deltaTime * jitter * ashMult;
       return { ...char, progress };
     });
 
-    // 2. Lock newly finished characters before event processing (higher progress = earlier finish)
+    // 2. Lock newly finished characters before event processing.
+    //    Sort by unclamped progress so same-tick finishers get accurate tie-break.
     const newlyFinishedChars = movedCharacters
       .filter((c) => c.progress >= FINISH_LINE && !state.finishedIds.includes(c.id))
       .sort((a, b) => b.progress - a.progress);
     const newlyFinishedIds = newlyFinishedChars.map((c) => c.id);
     const finishedIds = [...state.finishedIds, ...newlyFinishedIds];
 
-    // 2.5. Record finishTime on newly finished characters
+    // 2.5. Record finishTime + clamp progress to [0, 1] after tie-break is resolved
     const firstFinishTime =
       state.firstFinishTime ?? (newlyFinishedIds.length > 0 ? elapsedTime : null);
-    const withFinishTimes =
-      newlyFinishedIds.length > 0
-        ? movedCharacters.map((c) =>
-            newlyFinishedIds.includes(c.id) ? { ...c, finishTime: elapsedTime } : c,
-          )
-        : movedCharacters;
+    const withFinishTimes = movedCharacters.map((c) => {
+      const clampedProgress = Math.min(c.progress, 1);
+      if (newlyFinishedIds.includes(c.id)) {
+        return { ...c, progress: clampedProgress, finishTime: elapsedTime };
+      }
+      return clampedProgress !== c.progress ? { ...c, progress: clampedProgress } : c;
+    });
 
     // 3. Ranking
     const rankings = computeRankings(withFinishTimes);

--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -7,6 +7,7 @@ import {
   JITTER_RANGE,
   MAX_PLAYERS,
   MIN_PLAYERS,
+  RACE_END_GRACE_PERIOD_MS,
   VOLCANIC_ASH_SPEED_MULT,
 } from "../constants/balance";
 import {
@@ -81,11 +82,20 @@ function createCharacter(index: number): Character {
     status: "running",
     stunEndTime: 0,
     stats: { hitCount: 0, setbackTotal: 0, ultimateUsed: 0, rankChanges: 0 },
+    finishTime: null,
   };
 }
 
 function computeRankings(characters: Character[]): string[] {
   return [...characters].sort((a, b) => b.progress - a.progress).map((c) => c.id);
+}
+
+function computeFinalRankings(characters: Character[], finishedIds: string[]): string[] {
+  const unfinished = characters
+    .filter((c) => !finishedIds.includes(c.id))
+    .sort((a, b) => b.progress - a.progress)
+    .map((c) => c.id);
+  return [...finishedIds, ...unfinished];
 }
 
 // ── Initial state factory ──────────────────────────────────────────────────
@@ -104,6 +114,7 @@ interface InitialState {
   elapsedTime: number;
   rankings: string[];
   finishedIds: string[];
+  firstFinishTime: number | null;
   events: GameEvent[];
   activeGlobalEvent: GlobalEventType | null;
   globalEventEndTime: number;
@@ -126,6 +137,7 @@ function getInitialState(): InitialState {
     elapsedTime: 0,
     rankings: computeRankings(characters),
     finishedIds: [],
+    firstFinishTime: null,
     events: [],
     activeGlobalEvent: null,
     globalEventEndTime: 0,
@@ -185,6 +197,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       status: "running" as const,
       stunEndTime: 0,
       stats: { hitCount: 0, setbackTotal: 0, ultimateUsed: 0, rankChanges: 0 },
+      finishTime: null,
     }));
     initEventScheduler(0);
     initDialogueScheduler(0);
@@ -194,6 +207,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       hasResult: false,
       elapsedTime: 0,
       finishedIds: [],
+      firstFinishTime: null,
       events: [],
       eventLogs: [],
       activeGlobalEvent: null,
@@ -206,7 +220,12 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
 
   finishRace: () => {
-    set({ isRacing: false, hasResult: true });
+    const { characters, finishedIds } = get();
+    set({
+      isRacing: false,
+      hasResult: true,
+      rankings: computeFinalRankings(characters, finishedIds),
+    });
   },
 
   resetGame: () => {
@@ -248,18 +267,29 @@ export const useGameStore = create<GameState>((set, get) => ({
       return { ...char, progress };
     });
 
-    // 2. Lock newly finished characters before event processing
-    const newlyFinished = movedCharacters
+    // 2. Lock newly finished characters before event processing (higher progress = earlier finish)
+    const newlyFinishedChars = movedCharacters
       .filter((c) => c.progress >= FINISH_LINE && !state.finishedIds.includes(c.id))
-      .map((c) => c.id);
-    const finishedIds = [...state.finishedIds, ...newlyFinished];
+      .sort((a, b) => b.progress - a.progress);
+    const newlyFinishedIds = newlyFinishedChars.map((c) => c.id);
+    const finishedIds = [...state.finishedIds, ...newlyFinishedIds];
+
+    // 2.5. Record finishTime on newly finished characters
+    const firstFinishTime =
+      state.firstFinishTime ?? (newlyFinishedIds.length > 0 ? elapsedTime : null);
+    const withFinishTimes =
+      newlyFinishedIds.length > 0
+        ? movedCharacters.map((c) =>
+            newlyFinishedIds.includes(c.id) ? { ...c, finishTime: elapsedTime } : c,
+          )
+        : movedCharacters;
 
     // 3. Ranking
-    const rankings = computeRankings(movedCharacters);
+    const rankings = computeRankings(withFinishTimes);
 
     // 4. Event system — finished characters are protected from setback/stun
     const eventResult = processEvents({
-      characters: movedCharacters,
+      characters: withFinishTimes,
       rankings,
       finishedIds,
       elapsedTime,
@@ -270,23 +300,33 @@ export const useGameStore = create<GameState>((set, get) => ({
 
     // 5. Final state
     const finalCharacters = eventResult.characters;
-    const finalRankings = computeRankings(finalCharacters);
 
     // 5.5 Dialogue system
     const dialogueResult = processDialogues({
       characters: finalCharacters,
-      rankings: finalRankings,
+      rankings: computeRankings(finalCharacters),
       finishedIds,
       elapsedTime,
       activeBubble: state.activeBubble,
       newEvents: eventResult.newEvents,
     });
 
+    // 6. Race end condition: all finished OR grace period expired
     const isAllFinished = finishedIds.length === finalCharacters.length;
+    const gracePeriodSec = RACE_END_GRACE_PERIOD_MS / 1000;
+    const isGracePeriodOver =
+      firstFinishTime !== null && elapsedTime - firstFinishTime >= gracePeriodSec;
+    const shouldEndRace = isAllFinished || isGracePeriodOver;
+
+    const finalRankings = shouldEndRace
+      ? computeFinalRankings(finalCharacters, finishedIds)
+      : computeRankings(finalCharacters);
+
     set({
       characters: finalCharacters,
       rankings: finalRankings,
       finishedIds,
+      firstFinishTime,
       elapsedTime,
       events: [...state.events, ...eventResult.newEvents],
       eventLogs: [...state.eventLogs, ...eventResult.newLogs],
@@ -294,7 +334,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       globalEventEndTime: eventResult.globalEventEndTime,
       ultimateCount: eventResult.ultimateCount,
       activeBubble: dialogueResult.activeBubble,
-      ...(isAllFinished ? { isRacing: false, hasResult: true } : {}),
+      ...(shouldEndRace ? { isRacing: false, hasResult: true } : {}),
     });
   },
 

--- a/apps/web/src/features/mountain-race/types/index.ts
+++ b/apps/web/src/features/mountain-race/types/index.ts
@@ -33,6 +33,7 @@ export interface Character {
   status: CharacterStatus;
   stunEndTime: number;
   stats: CharacterStats;
+  finishTime: number | null;
 }
 
 // ── Event Types ────────────────────────────────────────────────────────────
@@ -106,6 +107,7 @@ export interface GameState {
   // ── Rankings ─────────────────────────────────────────────────────────────
   rankings: string[];
   finishedIds: string[];
+  firstFinishTime: number | null;
 
   // ── Events ───────────────────────────────────────────────────────────────
   events: GameEvent[];


### PR DESCRIPTION
## 요약

- Phase 6 결과 데이터 제공: 레이스 종료 규칙(전원 완주 OR 첫 골인 후 10초)과 최종 순위 확정 로직, 캐릭터별 finishTime 기록을 store에 추가

## 변경 사항

- `types/index.ts`: `Character`에 `finishTime: number | null`, `GameState`에 `firstFinishTime: number | null` 추가
- `useGameStore.ts`:
  - `computeFinalRankings()` — finishedIds(골인 순서) + 미완주자(progress 내림차순)로 최종 순위 확정
  - tick 내 grace period 종료 조건: `전원 완주 || (firstFinishTime + 10초 경과)`
  - 동일 tick 다중 골인 시 progress 내림차순 정렬로 순서 보장
  - `finishRace()` 액션에서도 `computeFinalRankings` 호출하여 경로 간 일관성 확보
  - 각 캐릭터 골인 시 `finishTime` 기록, `firstFinishTime` 자동 추적

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (pre-push hook으로 lint + format:check + typecheck + build 전체 통과)
  - [x] `pnpm format`
- 수동 확인: 없음 — 런타임 레이스 플레이 테스트는 미수행
- 실행하지 않은 검증과 이유: 브라우저 E2E 테스트 — 자동화 테스트 인프라 미구축 상태

## 스크린샷 또는 데모

- UI 변경 없음 (store/types 로직 변경만 포함)

## 문서 반영

- [x] 문서 변경 없음
- 관련 문서: `docs/plans/jeong-doeun-plan.md` Phase 6 항목에 해당하는 구현. plan 문서 자체 수정은 머지 후 진행 현황 업데이트 시 반영 예정

## 리스크와 후속 작업

- `Character.finishTime` 필드 추가로 다른 팀원(씬/UI)에서 Character 객체를 수동 생성하는 코드가 있다면 타입 에러 발생 가능 — typecheck 통과 확인으로 현재 codebase에서는 문제 없음
- grace period 동안 이벤트 시스템이 미완주 캐릭터에게 계속 발동됨 — PRD 의도와 일치하나 밸런스 튜닝 필요 가능
- `ResultScreen.tsx`는 현재 `rankings`(progress 기반)으로 표시 중이며, 이번 변경으로 종료 시 `computeFinalRankings` 결과가 rankings에 반영되어 별도 수정 없이 정확한 순위 표시
- 후속: plan 문서 진행 현황 업데이트, Phase 5 오버레이 실구현과 통합 테스트

Made with [Cursor](https://cursor.com)