### PR TITLE
feat(web): refine mountain trail scene readability

### DIFF
--- a/apps/web/src/features/mountain-race/components/Character.tsx
+++ b/apps/web/src/features/mountain-race/components/Character.tsx
@@ -4,9 +4,12 @@ import { Html } from "@react-three/drei";
 import type { Group } from "three";
 import { Vector3 } from "three";
 import type { Character as CharacterType } from "@/features/mountain-race/types";
-import { getTrackPoint, getTrackTangent } from "./Track";
+import { getTrackPointTo, getTrackSurfaceY, getTrackTangentTo } from "./Track";
 
 const _lookTarget = new Vector3();
+const _trackPoint = new Vector3();
+const _trackTangent = new Vector3();
+const CHARACTER_FOOT_CLEARANCE = 0.05;
 
 interface CharacterProps {
   character: CharacterType;
@@ -25,17 +28,21 @@ export function Character({ character, isFinished }: CharacterProps) {
     const group = groupRef.current;
     if (!group) return;
 
-    const pos = getTrackPoint(progress);
-    const tangent = getTrackTangent(progress);
+    const pos = getTrackPointTo(progress, _trackPoint);
+    const tangent = getTrackTangentTo(progress, _trackTangent);
+    const groundY = getTrackSurfaceY(progress);
 
-    group.position.lerp(pos, 0.15);
+    group.position.x += (pos.x - group.position.x) * 0.15;
+    group.position.z += (pos.z - group.position.z) * 0.15;
     _lookTarget.copy(group.position).add(tangent);
     group.lookAt(_lookTarget);
 
     if (canAnimate) {
       phaseRef.current += delta * 8 * animSpeed;
-      group.position.y += Math.sin(phaseRef.current) * 0.08;
     }
+
+    const targetY = groundY + CHARACTER_FOOT_CLEARANCE;
+    group.position.y += (targetY - group.position.y) * 0.2;
   });
 
   const emissive = statusEmissive(status);
@@ -51,8 +58,7 @@ export function Character({ character, isFinished }: CharacterProps) {
       <Belly color={color.inner} />
       <Backpack color={color.jacket} />
       <ArmPair color={color.jacket} canAnimate={canAnimate} animSpeed={animSpeed} />
-      <Pants color={color.pants} />
-      <Boots />
+      <LegPair color={color.pants} canAnimate={canAnimate} animSpeed={animSpeed} />
       <TrekkingPoles canAnimate={canAnimate} animSpeed={animSpeed} />
     </group>
   );
@@ -186,26 +192,49 @@ function Backpack({ color }: { color: string }) {
   );
 }
 
-function Pants({ color }: { color: string }) {
-  return (
-    <mesh position={[0, 0.4, 0]}>
-      <boxGeometry args={[0.45, 0.35, 0.28]} />
-      <meshStandardMaterial color={color} />
-    </mesh>
-  );
-}
+function LegPair({
+  color,
+  canAnimate,
+  animSpeed,
+}: {
+  color: string;
+  canAnimate: boolean;
+  animSpeed: number;
+}) {
+  const leftRef = useRef<Group>(null);
+  const rightRef = useRef<Group>(null);
+  const phaseRef = useRef(0);
 
-function Boots() {
+  useFrame((_, delta) => {
+    if (!canAnimate) return;
+    phaseRef.current += delta * 7 * animSpeed;
+    const swing = Math.sin(phaseRef.current) * 0.33 * animSpeed;
+    if (leftRef.current) leftRef.current.rotation.x = -swing;
+    if (rightRef.current) rightRef.current.rotation.x = swing;
+  });
+
   return (
     <>
-      <mesh position={[-0.12, 0.12, 0.04]}>
-        <boxGeometry args={[0.16, 0.14, 0.22]} />
-        <meshStandardMaterial color="#5C4033" />
-      </mesh>
-      <mesh position={[0.12, 0.12, 0.04]}>
-        <boxGeometry args={[0.16, 0.14, 0.22]} />
-        <meshStandardMaterial color="#5C4033" />
-      </mesh>
+      <group ref={leftRef} position={[-0.13, 0.36, 0.02]}>
+        <mesh position={[0, 0.12, 0]}>
+          <boxGeometry args={[0.16, 0.34, 0.16]} />
+          <meshStandardMaterial color={color} />
+        </mesh>
+        <mesh position={[0, -0.08, 0.05]}>
+          <boxGeometry args={[0.17, 0.12, 0.24]} />
+          <meshStandardMaterial color="#5C4033" />
+        </mesh>
+      </group>
+      <group ref={rightRef} position={[0.13, 0.36, 0.02]}>
+        <mesh position={[0, 0.12, 0]}>
+          <boxGeometry args={[0.16, 0.34, 0.16]} />
+          <meshStandardMaterial color={color} />
+        </mesh>
+        <mesh position={[0, -0.08, 0.05]}>
+          <boxGeometry args={[0.17, 0.12, 0.24]} />
+          <meshStandardMaterial color="#5C4033" />
+        </mesh>
+      </group>
     </>
   );
 }

--- a/apps/web/src/features/mountain-race/components/Environment.tsx
+++ b/apps/web/src/features/mountain-race/components/Environment.tsx
@@ -1,11 +1,27 @@
+import { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Object3D, type InstancedMesh } from "three";
 import type { GlobalEventType } from "@/features/mountain-race/types";
 
 interface EnvironmentProps {
   activeGlobalEvent: GlobalEventType | null;
+  leaderProgress?: number;
 }
 
-export function Environment({ activeGlobalEvent }: EnvironmentProps) {
+export function Environment({ activeGlobalEvent, leaderProgress = 0 }: EnvironmentProps) {
+  const isRainByAltitude = leaderProgress >= 0.58;
+  const isRainByEvent = activeGlobalEvent === "rain";
+  const isRainy = isRainByAltitude || isRainByEvent;
   const isFoggy = activeGlobalEvent === "fog";
+  const isStormy = activeGlobalEvent === "lightning";
+  const altitudeRainBoost = leaderProgress >= 0.8 ? 0.3 : leaderProgress >= 0.66 ? 0.18 : 0.08;
+  const rainIntensity = isRainy ? (isRainByEvent ? 0.62 : 0.48) + altitudeRainBoost : 0;
+  const rainSpeed = 20 + rainIntensity * 18;
+  const fogArgs = isFoggy
+    ? (["#bcc8d7", 8, 54] as const)
+    : isRainy
+      ? (["#b3becb", 24, 112] as const)
+      : (["#dfe6ee", 48, 210] as const);
 
   return (
     <group>
@@ -13,20 +29,38 @@ export function Environment({ activeGlobalEvent }: EnvironmentProps) {
       <Mountains />
       <Trees />
       <Clouds />
-      {isFoggy && <fog attach="fog" args={["#c8d6e5", 10, 60]} />}
-      {!isFoggy && <fog attach="fog" args={["#e8ecf1", 40, 200]} />}
-      <ambientLight intensity={0.4} />
-      <directionalLight position={[20, 50, 30]} intensity={1.0} />
+      {isRainy && <RainField intensity={rainIntensity} speed={rainSpeed} />}
+      <fog attach="fog" args={fogArgs} />
+      <ambientLight intensity={isStormy ? 0.28 : 0.42} />
+      <directionalLight
+        position={[20, 50, 30]}
+        intensity={isRainy ? 0.82 : 1.05}
+        color={isRainy ? "#d7e2f0" : "#fff7dd"}
+      />
     </group>
   );
 }
 
 function Ground() {
   return (
-    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.5, -60]}>
-      <planeGeometry args={[300, 300]} />
-      <meshStandardMaterial color="#4a7c59" roughness={1} />
-    </mesh>
+    <group>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -2.2, -72]}>
+        <planeGeometry args={[320, 340]} />
+        <meshStandardMaterial color="#3d5e46" roughness={1} />
+      </mesh>
+      <mesh position={[58, -7.5, -92]} scale={[42, 10, 62]}>
+        <dodecahedronGeometry args={[1, 0]} />
+        <meshStandardMaterial color="#4f6055" roughness={0.98} />
+      </mesh>
+      <mesh position={[-60, -8, -104]} scale={[46, 12, 68]}>
+        <dodecahedronGeometry args={[1, 0]} />
+        <meshStandardMaterial color="#4e6258" roughness={0.98} />
+      </mesh>
+      <mesh position={[0, -10.5, -142]} scale={[58, 15, 52]}>
+        <dodecahedronGeometry args={[1, 0]} />
+        <meshStandardMaterial color="#53675f" roughness={0.98} />
+      </mesh>
+    </group>
   );
 }
 
@@ -58,24 +92,41 @@ function Mountains() {
   );
 }
 
-const TREE_DATA = [
-  { id: "tr-a", pos: [8, 0, -10] as const },
-  { id: "tr-b", pos: [-6, 2, -15] as const },
-  { id: "tr-c", pos: [14, 4, -35] as const },
-  { id: "tr-d", pos: [-12, 6, -45] as const },
-  { id: "tr-e", pos: [6, 10, -55] as const },
-  { id: "tr-f", pos: [-8, 14, -75] as const },
-  { id: "tr-g", pos: [12, 18, -85] as const },
-  { id: "tr-h", pos: [-4, 22, -95] as const },
-  { id: "tr-i", pos: [10, 28, -105] as const },
-  { id: "tr-j", pos: [-10, 32, -115] as const },
-];
+const TREE_DATA = buildTreeData();
+
+function buildTreeData(): { id: string; pos: [number, number, number]; scale: number }[] {
+  const trees: { id: string; pos: [number, number, number]; scale: number }[] = [];
+  const zones = [
+    { name: "low", count: 42, zStart: -8, zEnd: -56, minOffset: 9, maxOffset: 17, yBase: -0.5 },
+    { name: "mid", count: 28, zStart: -58, zEnd: -104, minOffset: 10, maxOffset: 18, yBase: 4.5 },
+    { name: "peak", count: 18, zStart: -106, zEnd: -152, minOffset: 11, maxOffset: 21, yBase: 10.5 },
+  ] as const;
+  let treeIndex = 0;
+
+  for (const zone of zones) {
+    for (let i = 0; i < zone.count; i++) {
+      const lane = i % 2 === 0 ? 1 : -1;
+      const t = zone.count <= 1 ? 0 : i / (zone.count - 1);
+      const z = zone.zStart + (zone.zEnd - zone.zStart) * t + Math.sin((treeIndex + 1) * 1.12) * 0.9;
+      const spreadSeed = (Math.sin((treeIndex + 1) * 2.17) * 0.5 + 0.5);
+      const offset = zone.minOffset + spreadSeed * (zone.maxOffset - zone.minOffset);
+      const x = lane * (offset + Math.cos((treeIndex + 3) * 0.91) * 1.7);
+      const y = zone.yBase + Math.sin((treeIndex + 2) * 0.58) * 1.2 + t * 2.6;
+      const scaleBase = zone.name === "low" ? 1.02 : zone.name === "mid" ? 0.9 : 0.76;
+      const scale = scaleBase + ((treeIndex % 4) * 0.07);
+      trees.push({ id: `tr-${treeIndex}`, pos: [x, y, z], scale });
+      treeIndex += 1;
+    }
+  }
+
+  return trees;
+}
 
 function Trees() {
   return (
     <group>
       {TREE_DATA.map((t) => (
-        <group key={t.id} position={[t.pos[0], t.pos[1], t.pos[2]]}>
+        <group key={t.id} position={[t.pos[0], t.pos[1], t.pos[2]]} scale={t.scale}>
           {/* trunk */}
           <mesh position={[0, 0.6, 0]}>
             <cylinderGeometry args={[0.08, 0.12, 1.2, 5]} />
@@ -97,18 +148,21 @@ function Trees() {
 }
 
 const CLOUD_DATA = [
-  { id: "cl-a", pos: [15, 30, -30] as const },
-  { id: "cl-b", pos: [-20, 35, -60] as const },
-  { id: "cl-c", pos: [25, 32, -90] as const },
-  { id: "cl-d", pos: [-15, 38, -120] as const },
-  { id: "cl-e", pos: [10, 40, -150] as const },
+  { id: "cl-a", pos: [16, 28, -24] as const, scale: 1.2 },
+  { id: "cl-b", pos: [-22, 34, -42] as const, scale: 1.1 },
+  { id: "cl-c", pos: [24, 31, -64] as const, scale: 1.25 },
+  { id: "cl-d", pos: [-16, 38, -84] as const, scale: 1.35 },
+  { id: "cl-e", pos: [10, 36, -102] as const, scale: 1.15 },
+  { id: "cl-f", pos: [-8, 43, -118] as const, scale: 1.5 },
+  { id: "cl-g", pos: [18, 39, -136] as const, scale: 1.4 },
+  { id: "cl-h", pos: [-24, 45, -152] as const, scale: 1.55 },
 ];
 
 function Clouds() {
   return (
     <group>
       {CLOUD_DATA.map((c) => (
-        <group key={c.id} position={[c.pos[0], c.pos[1], c.pos[2]]}>
+        <group key={c.id} position={[c.pos[0], c.pos[1], c.pos[2]]} scale={c.scale}>
           <mesh>
             <sphereGeometry args={[2, 8, 6]} />
             <meshStandardMaterial color="#ffffff" transparent opacity={0.7} />
@@ -124,5 +178,71 @@ function Clouds() {
         </group>
       ))}
     </group>
+  );
+}
+
+const RAIN_DROP_COUNT_MAX = 360;
+const RAIN_RANGE_X = 34;
+const RAIN_RANGE_Z = 170;
+const RAIN_MIN_Y = 6;
+const RAIN_MAX_Y = 64;
+const _instanceDummy = new Object3D();
+
+function RainField({ intensity, speed }: { intensity: number; speed: number }) {
+  const meshRef = useRef<InstancedMesh>(null);
+  const activeDropCount = Math.max(90, Math.floor(RAIN_DROP_COUNT_MAX * Math.min(1, intensity)));
+  const drops = useMemo(
+    () =>
+      Array.from({ length: RAIN_DROP_COUNT_MAX }, (_, i) => ({
+        x: (Math.sin(i * 17.17) * 0.5 + 0.5) * RAIN_RANGE_X - RAIN_RANGE_X / 2,
+        y: RAIN_MIN_Y + ((Math.cos(i * 23.41) * 0.5 + 0.5) * (RAIN_MAX_Y - RAIN_MIN_Y)),
+        z: -((Math.sin(i * 7.23) * 0.5 + 0.5) * RAIN_RANGE_Z),
+      })),
+    [],
+  );
+
+  useFrame((_, delta) => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    for (let i = 0; i < drops.length; i++) {
+      const drop = drops[i];
+      if (!drop) continue;
+
+      if (i >= activeDropCount) {
+        _instanceDummy.position.set(0, -1000, 0);
+        _instanceDummy.updateMatrix();
+        mesh.setMatrixAt(i, _instanceDummy.matrix);
+        continue;
+      }
+
+      drop.y -= delta * speed;
+      drop.x -= delta * (2.3 + intensity * 2.4);
+
+      if (drop.y < RAIN_MIN_Y) {
+        drop.y = RAIN_MAX_Y;
+      }
+      if (drop.x < -RAIN_RANGE_X / 2) {
+        drop.x = RAIN_RANGE_X / 2;
+      }
+
+      _instanceDummy.position.set(drop.x, drop.y, drop.z);
+      _instanceDummy.rotation.set(0.3, 0, 0.1);
+      _instanceDummy.updateMatrix();
+      mesh.setMatrixAt(i, _instanceDummy.matrix);
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh ref={meshRef} args={[undefined, undefined, RAIN_DROP_COUNT_MAX]}>
+      <boxGeometry args={[0.028, 0.82, 0.028]} />
+      <meshStandardMaterial
+        color="#b7d5ff"
+        transparent
+        opacity={Math.min(0.78, 0.35 + intensity * 0.48)}
+      />
+    </instancedMesh>
   );
 }

--- a/apps/web/src/features/mountain-race/components/Environment.tsx
+++ b/apps/web/src/features/mountain-race/components/Environment.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Object3D, type InstancedMesh } from "three";
 import type { GlobalEventType } from "@/features/mountain-race/types";
@@ -9,19 +9,27 @@ interface EnvironmentProps {
 }
 
 export function Environment({ activeGlobalEvent, leaderProgress = 0 }: EnvironmentProps) {
-  const isRainByAltitude = leaderProgress >= 0.58;
+  const isRainByAltitude = leaderProgress >= WEATHER_CONFIG.altitudeRainStart;
   const isRainByEvent = activeGlobalEvent === "rain";
   const isRainy = isRainByAltitude || isRainByEvent;
   const isFoggy = activeGlobalEvent === "fog";
   const isStormy = activeGlobalEvent === "lightning";
-  const altitudeRainBoost = leaderProgress >= 0.8 ? 0.3 : leaderProgress >= 0.66 ? 0.18 : 0.08;
-  const rainIntensity = isRainy ? (isRainByEvent ? 0.62 : 0.48) + altitudeRainBoost : 0;
-  const rainSpeed = 20 + rainIntensity * 18;
+  const altitudeRainBoost =
+    leaderProgress >= WEATHER_CONFIG.altitudeHeavyRain
+      ? WEATHER_CONFIG.altitudeBoostHigh
+      : leaderProgress >= WEATHER_CONFIG.altitudeMidRain
+        ? WEATHER_CONFIG.altitudeBoostMid
+        : WEATHER_CONFIG.altitudeBoostLow;
+  const rainIntensity = isRainy
+    ? (isRainByEvent ? WEATHER_CONFIG.eventRainBase : WEATHER_CONFIG.altitudeRainBase) +
+      altitudeRainBoost
+    : 0;
+  const rainSpeed = WEATHER_CONFIG.rainSpeedBase + rainIntensity * WEATHER_CONFIG.rainSpeedGain;
   const fogArgs = isFoggy
-    ? (["#bcc8d7", 8, 54] as const)
+    ? WEATHER_CONFIG.fogDense
     : isRainy
-      ? (["#b3becb", 24, 112] as const)
-      : (["#dfe6ee", 48, 210] as const);
+      ? WEATHER_CONFIG.fogRain
+      : WEATHER_CONFIG.fogClear;
 
   return (
     <group>
@@ -31,15 +39,38 @@ export function Environment({ activeGlobalEvent, leaderProgress = 0 }: Environme
       <Clouds />
       {isRainy && <RainField intensity={rainIntensity} speed={rainSpeed} />}
       <fog attach="fog" args={fogArgs} />
-      <ambientLight intensity={isStormy ? 0.28 : 0.42} />
+      <ambientLight intensity={isStormy ? WEATHER_CONFIG.stormAmbient : WEATHER_CONFIG.defaultAmbient} />
       <directionalLight
-        position={[20, 50, 30]}
-        intensity={isRainy ? 0.82 : 1.05}
-        color={isRainy ? "#d7e2f0" : "#fff7dd"}
+        position={WEATHER_CONFIG.sunPosition}
+        intensity={isRainy ? WEATHER_CONFIG.rainSunIntensity : WEATHER_CONFIG.clearSunIntensity}
+        color={isRainy ? WEATHER_CONFIG.rainSunColor : WEATHER_CONFIG.clearSunColor}
       />
     </group>
   );
 }
+
+const WEATHER_CONFIG = {
+  altitudeRainStart: 0.58,
+  altitudeMidRain: 0.66,
+  altitudeHeavyRain: 0.8,
+  altitudeBoostLow: 0.08,
+  altitudeBoostMid: 0.18,
+  altitudeBoostHigh: 0.3,
+  altitudeRainBase: 0.48,
+  eventRainBase: 0.62,
+  rainSpeedBase: 20,
+  rainSpeedGain: 18,
+  fogDense: ["#bcc8d7", 8, 54] as const,
+  fogRain: ["#b3becb", 24, 112] as const,
+  fogClear: ["#dfe6ee", 48, 210] as const,
+  stormAmbient: 0.28,
+  defaultAmbient: 0.42,
+  sunPosition: [20, 50, 30] as const,
+  rainSunIntensity: 0.82,
+  clearSunIntensity: 1.05,
+  rainSunColor: "#d7e2f0",
+  clearSunColor: "#fff7dd",
+} as const;
 
 function Ground() {
   return (
@@ -92,68 +123,102 @@ function Mountains() {
   );
 }
 
+function Trees() {
+  const trunkRef = useRef<InstancedMesh>(null);
+  const canopyLowerRef = useRef<InstancedMesh>(null);
+  const canopyUpperRef = useRef<InstancedMesh>(null);
+  const dummyRef = useRef(new Object3D());
+
+  useLayoutEffect(() => {
+    const trunk = trunkRef.current;
+    const lower = canopyLowerRef.current;
+    const upper = canopyUpperRef.current;
+    const dummy = dummyRef.current;
+    if (!trunk || !lower || !upper) return;
+
+    for (let i = 0; i < TREE_DATA.length; i++) {
+      const tree = TREE_DATA[i];
+      if (!tree) continue;
+      const [x, y, z] = tree.pos;
+      const s = tree.scale;
+
+      dummy.rotation.set(0, 0, 0);
+
+      dummy.position.set(x, y + 0.6 * s, z);
+      dummy.scale.set(s, s, s);
+      dummy.updateMatrix();
+      trunk.setMatrixAt(i, dummy.matrix);
+
+      dummy.position.set(x, y + 1.6 * s, z);
+      dummy.scale.set(s, s, s);
+      dummy.updateMatrix();
+      lower.setMatrixAt(i, dummy.matrix);
+
+      dummy.position.set(x, y + 2.2 * s, z);
+      dummy.scale.set(s, s, s);
+      dummy.updateMatrix();
+      upper.setMatrixAt(i, dummy.matrix);
+    }
+
+    trunk.instanceMatrix.needsUpdate = true;
+    lower.instanceMatrix.needsUpdate = true;
+    upper.instanceMatrix.needsUpdate = true;
+  }, []);
+
+  return (
+    <group>
+      <instancedMesh ref={trunkRef} args={[undefined, undefined, TREE_DATA.length]}>
+        <cylinderGeometry args={[0.08, 0.12, 1.2, 5]} />
+        <meshStandardMaterial color="#6b4226" />
+      </instancedMesh>
+      <instancedMesh ref={canopyLowerRef} args={[undefined, undefined, TREE_DATA.length]}>
+        <coneGeometry args={[0.6, 1.4, 6]} />
+        <meshStandardMaterial color="#2d6a4f" />
+      </instancedMesh>
+      <instancedMesh ref={canopyUpperRef} args={[undefined, undefined, TREE_DATA.length]}>
+        <coneGeometry args={[0.45, 1.0, 6]} />
+        <meshStandardMaterial color="#40916c" />
+      </instancedMesh>
+    </group>
+  );
+}
+
+const TREE_CONFIG = {
+  seed: 20260404,
+  zJitter: 0.9,
+  xJitter: 1.7,
+  yJitter: 1.2,
+  altitudeGrow: 2.6,
+  scaleVariance: 0.24,
+  zones: [
+    { count: 42, zStart: -8, zEnd: -56, minOffset: 9, maxOffset: 17, yBase: -0.5, scaleBase: 0.95 },
+    { count: 28, zStart: -58, zEnd: -104, minOffset: 10, maxOffset: 18, yBase: 4.5, scaleBase: 0.84 },
+    { count: 18, zStart: -106, zEnd: -152, minOffset: 11, maxOffset: 21, yBase: 10.5, scaleBase: 0.72 },
+  ] as const,
+} as const;
+
 const TREE_DATA = buildTreeData();
 
 function buildTreeData(): { id: string; pos: [number, number, number]; scale: number }[] {
   const trees: { id: string; pos: [number, number, number]; scale: number }[] = [];
-  const zones = [
-    { name: "low", count: 42, zStart: -8, zEnd: -56, minOffset: 9, maxOffset: 17, yBase: -0.5 },
-    { name: "mid", count: 28, zStart: -58, zEnd: -104, minOffset: 10, maxOffset: 18, yBase: 4.5 },
-    {
-      name: "peak",
-      count: 18,
-      zStart: -106,
-      zEnd: -152,
-      minOffset: 11,
-      maxOffset: 21,
-      yBase: 10.5,
-    },
-  ] as const;
+  const rng = mulberry32(TREE_CONFIG.seed);
   let treeIndex = 0;
 
-  for (const zone of zones) {
+  for (const zone of TREE_CONFIG.zones) {
     for (let i = 0; i < zone.count; i++) {
       const lane = i % 2 === 0 ? 1 : -1;
       const t = zone.count <= 1 ? 0 : i / (zone.count - 1);
-      const z =
-        zone.zStart + (zone.zEnd - zone.zStart) * t + Math.sin((treeIndex + 1) * 1.12) * 0.9;
-      const spreadSeed = Math.sin((treeIndex + 1) * 2.17) * 0.5 + 0.5;
-      const offset = zone.minOffset + spreadSeed * (zone.maxOffset - zone.minOffset);
-      const x = lane * (offset + Math.cos((treeIndex + 3) * 0.91) * 1.7);
-      const y = zone.yBase + Math.sin((treeIndex + 2) * 0.58) * 1.2 + t * 2.6;
-      const scaleBase = zone.name === "low" ? 1.02 : zone.name === "mid" ? 0.9 : 0.76;
-      const scale = scaleBase + (treeIndex % 4) * 0.07;
+      const z = zone.zStart + (zone.zEnd - zone.zStart) * t + jitter(rng, TREE_CONFIG.zJitter);
+      const offset = zone.minOffset + rng() * (zone.maxOffset - zone.minOffset);
+      const x = lane * (offset + jitter(rng, TREE_CONFIG.xJitter));
+      const y = zone.yBase + jitter(rng, TREE_CONFIG.yJitter) + t * TREE_CONFIG.altitudeGrow;
+      const scale = zone.scaleBase + rng() * TREE_CONFIG.scaleVariance;
       trees.push({ id: `tr-${treeIndex}`, pos: [x, y, z], scale });
       treeIndex += 1;
     }
   }
 
   return trees;
-}
-
-function Trees() {
-  return (
-    <group>
-      {TREE_DATA.map((t) => (
-        <group key={t.id} position={[t.pos[0], t.pos[1], t.pos[2]]} scale={t.scale}>
-          {/* trunk */}
-          <mesh position={[0, 0.6, 0]}>
-            <cylinderGeometry args={[0.08, 0.12, 1.2, 5]} />
-            <meshStandardMaterial color="#6b4226" />
-          </mesh>
-          {/* canopy */}
-          <mesh position={[0, 1.6, 0]}>
-            <coneGeometry args={[0.6, 1.4, 6]} />
-            <meshStandardMaterial color="#2d6a4f" />
-          </mesh>
-          <mesh position={[0, 2.2, 0]}>
-            <coneGeometry args={[0.45, 1.0, 6]} />
-            <meshStandardMaterial color="#40916c" />
-          </mesh>
-        </group>
-      ))}
-    </group>
-  );
 }
 
 const CLOUD_DATA = [
@@ -190,28 +255,42 @@ function Clouds() {
   );
 }
 
-const RAIN_DROP_COUNT_MAX = 360;
-const RAIN_RANGE_X = 34;
-const RAIN_RANGE_Z = 170;
-const RAIN_MIN_Y = 6;
-const RAIN_MAX_Y = 64;
-const _instanceDummy = new Object3D();
+const RAIN_CONFIG = {
+  maxDropCount: 360,
+  minDropCount: 90,
+  rangeX: 34,
+  rangeZ: 170,
+  minY: 6,
+  maxY: 64,
+  windBase: 2.3,
+  windGain: 2.4,
+} as const;
+
+type RainDrop = { x: number; y: number; z: number };
 
 function RainField({ intensity, speed }: { intensity: number; speed: number }) {
   const meshRef = useRef<InstancedMesh>(null);
-  const activeDropCount = Math.max(90, Math.floor(RAIN_DROP_COUNT_MAX * Math.min(1, intensity)));
-  const drops = useMemo(
-    () =>
-      Array.from({ length: RAIN_DROP_COUNT_MAX }, (_, i) => ({
-        x: (Math.sin(i * 17.17) * 0.5 + 0.5) * RAIN_RANGE_X - RAIN_RANGE_X / 2,
-        y: RAIN_MIN_Y + (Math.cos(i * 23.41) * 0.5 + 0.5) * (RAIN_MAX_Y - RAIN_MIN_Y),
-        z: -((Math.sin(i * 7.23) * 0.5 + 0.5) * RAIN_RANGE_Z),
-      })),
-    [],
+  const activeDropCount = Math.max(
+    RAIN_CONFIG.minDropCount,
+    Math.floor(RAIN_CONFIG.maxDropCount * Math.min(1, intensity)),
   );
+  const dropsRef = useRef<RainDrop[]>([]);
+  const dummyRef = useRef(new Object3D());
+
+  if (dropsRef.current.length === 0) {
+    dropsRef.current = Array.from({ length: RAIN_CONFIG.maxDropCount }, (_, i) => ({
+      x: (Math.sin(i * 17.17) * 0.5 + 0.5) * RAIN_CONFIG.rangeX - RAIN_CONFIG.rangeX / 2,
+      y:
+        RAIN_CONFIG.minY +
+        (Math.cos(i * 23.41) * 0.5 + 0.5) * (RAIN_CONFIG.maxY - RAIN_CONFIG.minY),
+      z: -((Math.sin(i * 7.23) * 0.5 + 0.5) * RAIN_CONFIG.rangeZ),
+    }));
+  }
 
   useFrame((_, delta) => {
     const mesh = meshRef.current;
+    const dummy = dummyRef.current;
+    const drops = dropsRef.current;
     if (!mesh) return;
 
     for (let i = 0; i < drops.length; i++) {
@@ -219,33 +298,33 @@ function RainField({ intensity, speed }: { intensity: number; speed: number }) {
       if (!drop) continue;
 
       if (i >= activeDropCount) {
-        _instanceDummy.position.set(0, -1000, 0);
-        _instanceDummy.updateMatrix();
-        mesh.setMatrixAt(i, _instanceDummy.matrix);
+        dummy.position.set(0, -1000, 0);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(i, dummy.matrix);
         continue;
       }
 
       drop.y -= delta * speed;
-      drop.x -= delta * (2.3 + intensity * 2.4);
+      drop.x -= delta * (RAIN_CONFIG.windBase + intensity * RAIN_CONFIG.windGain);
 
-      if (drop.y < RAIN_MIN_Y) {
-        drop.y = RAIN_MAX_Y;
+      if (drop.y < RAIN_CONFIG.minY) {
+        drop.y = RAIN_CONFIG.maxY;
       }
-      if (drop.x < -RAIN_RANGE_X / 2) {
-        drop.x = RAIN_RANGE_X / 2;
+      if (drop.x < -RAIN_CONFIG.rangeX / 2) {
+        drop.x = RAIN_CONFIG.rangeX / 2;
       }
 
-      _instanceDummy.position.set(drop.x, drop.y, drop.z);
-      _instanceDummy.rotation.set(0.3, 0, 0.1);
-      _instanceDummy.updateMatrix();
-      mesh.setMatrixAt(i, _instanceDummy.matrix);
+      dummy.position.set(drop.x, drop.y, drop.z);
+      dummy.rotation.set(0.3, 0, 0.1);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
     }
 
     mesh.instanceMatrix.needsUpdate = true;
   });
 
   return (
-    <instancedMesh ref={meshRef} args={[undefined, undefined, RAIN_DROP_COUNT_MAX]}>
+    <instancedMesh ref={meshRef} args={[undefined, undefined, RAIN_CONFIG.maxDropCount]}>
       <boxGeometry args={[0.028, 0.82, 0.028]} />
       <meshStandardMaterial
         color="#b7d5ff"
@@ -254,4 +333,18 @@ function RainField({ intensity, speed }: { intensity: number; speed: number }) {
       />
     </instancedMesh>
   );
+}
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), t | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function jitter(rng: () => number, amount: number): number {
+  return (rng() * 2 - 1) * amount;
 }

--- a/apps/web/src/features/mountain-race/components/Environment.tsx
+++ b/apps/web/src/features/mountain-race/components/Environment.tsx
@@ -39,7 +39,9 @@ export function Environment({ activeGlobalEvent, leaderProgress = 0 }: Environme
       <Clouds />
       {isRainy && <RainField intensity={rainIntensity} speed={rainSpeed} />}
       <fog attach="fog" args={fogArgs} />
-      <ambientLight intensity={isStormy ? WEATHER_CONFIG.stormAmbient : WEATHER_CONFIG.defaultAmbient} />
+      <ambientLight
+        intensity={isStormy ? WEATHER_CONFIG.stormAmbient : WEATHER_CONFIG.defaultAmbient}
+      />
       <directionalLight
         position={WEATHER_CONFIG.sunPosition}
         intensity={isRainy ? WEATHER_CONFIG.rainSunIntensity : WEATHER_CONFIG.clearSunIntensity}
@@ -192,8 +194,24 @@ const TREE_CONFIG = {
   scaleVariance: 0.24,
   zones: [
     { count: 42, zStart: -8, zEnd: -56, minOffset: 9, maxOffset: 17, yBase: -0.5, scaleBase: 0.95 },
-    { count: 28, zStart: -58, zEnd: -104, minOffset: 10, maxOffset: 18, yBase: 4.5, scaleBase: 0.84 },
-    { count: 18, zStart: -106, zEnd: -152, minOffset: 11, maxOffset: 21, yBase: 10.5, scaleBase: 0.72 },
+    {
+      count: 28,
+      zStart: -58,
+      zEnd: -104,
+      minOffset: 10,
+      maxOffset: 18,
+      yBase: 4.5,
+      scaleBase: 0.84,
+    },
+    {
+      count: 18,
+      zStart: -106,
+      zEnd: -152,
+      minOffset: 11,
+      maxOffset: 21,
+      yBase: 10.5,
+      scaleBase: 0.72,
+    },
   ] as const,
 } as const;
 

--- a/apps/web/src/features/mountain-race/components/Environment.tsx
+++ b/apps/web/src/features/mountain-race/components/Environment.tsx
@@ -99,7 +99,15 @@ function buildTreeData(): { id: string; pos: [number, number, number]; scale: nu
   const zones = [
     { name: "low", count: 42, zStart: -8, zEnd: -56, minOffset: 9, maxOffset: 17, yBase: -0.5 },
     { name: "mid", count: 28, zStart: -58, zEnd: -104, minOffset: 10, maxOffset: 18, yBase: 4.5 },
-    { name: "peak", count: 18, zStart: -106, zEnd: -152, minOffset: 11, maxOffset: 21, yBase: 10.5 },
+    {
+      name: "peak",
+      count: 18,
+      zStart: -106,
+      zEnd: -152,
+      minOffset: 11,
+      maxOffset: 21,
+      yBase: 10.5,
+    },
   ] as const;
   let treeIndex = 0;
 
@@ -107,13 +115,14 @@ function buildTreeData(): { id: string; pos: [number, number, number]; scale: nu
     for (let i = 0; i < zone.count; i++) {
       const lane = i % 2 === 0 ? 1 : -1;
       const t = zone.count <= 1 ? 0 : i / (zone.count - 1);
-      const z = zone.zStart + (zone.zEnd - zone.zStart) * t + Math.sin((treeIndex + 1) * 1.12) * 0.9;
-      const spreadSeed = (Math.sin((treeIndex + 1) * 2.17) * 0.5 + 0.5);
+      const z =
+        zone.zStart + (zone.zEnd - zone.zStart) * t + Math.sin((treeIndex + 1) * 1.12) * 0.9;
+      const spreadSeed = Math.sin((treeIndex + 1) * 2.17) * 0.5 + 0.5;
       const offset = zone.minOffset + spreadSeed * (zone.maxOffset - zone.minOffset);
       const x = lane * (offset + Math.cos((treeIndex + 3) * 0.91) * 1.7);
       const y = zone.yBase + Math.sin((treeIndex + 2) * 0.58) * 1.2 + t * 2.6;
       const scaleBase = zone.name === "low" ? 1.02 : zone.name === "mid" ? 0.9 : 0.76;
-      const scale = scaleBase + ((treeIndex % 4) * 0.07);
+      const scale = scaleBase + (treeIndex % 4) * 0.07;
       trees.push({ id: `tr-${treeIndex}`, pos: [x, y, z], scale });
       treeIndex += 1;
     }
@@ -195,7 +204,7 @@ function RainField({ intensity, speed }: { intensity: number; speed: number }) {
     () =>
       Array.from({ length: RAIN_DROP_COUNT_MAX }, (_, i) => ({
         x: (Math.sin(i * 17.17) * 0.5 + 0.5) * RAIN_RANGE_X - RAIN_RANGE_X / 2,
-        y: RAIN_MIN_Y + ((Math.cos(i * 23.41) * 0.5 + 0.5) * (RAIN_MAX_Y - RAIN_MIN_Y)),
+        y: RAIN_MIN_Y + (Math.cos(i * 23.41) * 0.5 + 0.5) * (RAIN_MAX_Y - RAIN_MIN_Y),
         z: -((Math.sin(i * 7.23) * 0.5 + 0.5) * RAIN_RANGE_Z),
       })),
     [],

--- a/apps/web/src/features/mountain-race/components/HUD.tsx
+++ b/apps/web/src/features/mountain-race/components/HUD.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useGameStore } from "../store/useGameStore";
-import { FINISH_LINE } from "../constants/balance";
+import { FINISH_LINE, RACE_END_GRACE_PERIOD_MS } from "../constants/balance";
 import type { CharacterStatus } from "../types";
 
 const STATUS_INDICATORS: Partial<Record<CharacterStatus, string>> = {
@@ -18,15 +18,33 @@ export function HUD() {
   const rankings = useGameStore((s) => s.rankings);
   const finishedIds = useGameStore((s) => s.finishedIds);
   const activeGlobalEvent = useGameStore((s) => s.activeGlobalEvent);
+  const firstFinishTime = useGameStore((s) => s.firstFinishTime);
+  const elapsedTime = useGameStore((s) => s.elapsedTime);
+  const isRacing = useGameStore((s) => s.isRacing);
 
   const isFogActive = activeGlobalEvent === "fog";
 
   const characterMap = useMemo(() => new Map(characters.map((c) => [c.id, c])), [characters]);
 
   const finishedSet = useMemo(() => new Set(finishedIds), [finishedIds]);
+  const isAllFinished = finishedIds.length >= characters.length && characters.length > 0;
+
+  const raceEndCountdownSec = useMemo(() => {
+    if (!isRacing || isAllFinished || firstFinishTime === null) return null;
+    const elapsedSinceFirstFinishMs = (elapsedTime - firstFinishTime) * 1000;
+    const remainingMs = Math.max(0, RACE_END_GRACE_PERIOD_MS - elapsedSinceFirstFinishMs);
+    return Math.ceil(remainingMs / 1000);
+  }, [elapsedTime, firstFinishTime, isAllFinished, isRacing]);
 
   return (
     <>
+      {raceEndCountdownSec !== null && (
+        <div className="absolute top-3 left-1/2 z-30 -translate-x-1/2 rounded-xl bg-black/60 px-4 py-2 text-center text-white backdrop-blur-sm">
+          <div className="text-xs font-semibold text-amber-300">선두 골인</div>
+          <div className="text-sm font-bold">레이스 종료까지 {raceEndCountdownSec}초</div>
+        </div>
+      )}
+
       {/* ── Ranking list — top right ─────────────────────────────────── */}
       <div className="absolute top-3 right-3 z-20 flex max-h-[70vh] flex-col gap-1 overflow-y-auto">
         {rankings.map((id, index) => {

--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { CatmullRomCurve3, Vector3 } from "three";
+import { useLayoutEffect, useMemo, useRef } from "react";
+import { CatmullRomCurve3, Object3D, type InstancedMesh, Vector3 } from "three";
 import { FINISH_LINE } from "@/features/mountain-race/constants";
 
 const TRACK_POINTS = [
@@ -14,12 +14,30 @@ const TRACK_POINTS = [
   new Vector3(0, 24, -142),
 ];
 
-const TRAIL_SAMPLE_COUNT = 200;
-const TRAIL_WIDTH = 2.4;
-const TRAIL_THICKNESS = 0.2;
-const TRAIL_STONE_EVERY = 5;
-const TRAIL_CENTER_Y_OFFSET = 0.08;
-export const TRACK_SURFACE_Y_OFFSET = TRAIL_CENTER_Y_OFFSET + TRAIL_THICKNESS / 2;
+const TRAIL_CONFIG = {
+  sampleCount: 200,
+  width: 2.4,
+  thickness: 0.2,
+  stoneEvery: 5,
+  centerYOffset: 0.08,
+  segmentLengthPad: 0.12,
+  stoneSideOffset: 1.55,
+  stoneLeftY: 0.45,
+  stoneRightY: 0.42,
+  ridge: {
+    baseHeight: 2.8,
+    growHeight: 5.2,
+    baseWidth: 8.5,
+    growWidth: 4.5,
+    sinkRatio: 0.65,
+    lengthPad: 1.8,
+    rollScale: 0.3,
+  },
+  rollFrequency: 0.37,
+  rollAmount: 0.05,
+} as const;
+
+export const TRACK_SURFACE_Y_OFFSET = TRAIL_CONFIG.centerYOffset + TRAIL_CONFIG.thickness / 2;
 const _surfacePoint = new Vector3();
 
 export const trackCurve = new CatmullRomCurve3(TRACK_POINTS, false, "catmullrom", 0.3);
@@ -84,28 +102,48 @@ function FinishLine() {
 }
 
 interface TrailSegment {
-  id: string;
   position: [number, number, number];
   rotation: [number, number, number];
-  length: number;
+  scale: [number, number, number];
 }
 
 interface TrailStone {
-  id: string;
   position: [number, number, number];
+  rotation: [number, number, number];
   scale: [number, number, number];
 }
 
 interface TrailRidge {
-  id: string;
   position: [number, number, number];
   rotation: [number, number, number];
   scale: [number, number, number];
 }
 
+const _instanceObject = new Object3D();
+
+function applyInstanceTransforms(
+  mesh: InstancedMesh,
+  transforms: { position: [number, number, number]; rotation: [number, number, number]; scale: [number, number, number] }[],
+) {
+  for (let i = 0; i < transforms.length; i++) {
+    const transform = transforms[i];
+    if (!transform) continue;
+    _instanceObject.position.set(transform.position[0], transform.position[1], transform.position[2]);
+    _instanceObject.rotation.set(transform.rotation[0], transform.rotation[1], transform.rotation[2]);
+    _instanceObject.scale.set(transform.scale[0], transform.scale[1], transform.scale[2]);
+    _instanceObject.updateMatrix();
+    mesh.setMatrixAt(i, _instanceObject.matrix);
+  }
+  mesh.instanceMatrix.needsUpdate = true;
+}
+
 export function Track() {
+  const segmentRef = useRef<InstancedMesh>(null);
+  const stoneRef = useRef<InstancedMesh>(null);
+  const ridgeRef = useRef<InstancedMesh>(null);
+
   const { segments, stones, ridges } = useMemo(() => {
-    const sampled = trackCurve.getSpacedPoints(TRAIL_SAMPLE_COUNT);
+    const sampled = trackCurve.getSpacedPoints(TRAIL_CONFIG.sampleCount);
     const outputSegments: TrailSegment[] = [];
     const outputStones: TrailStone[] = [];
     const outputRidges: TrailRidge[] = [];
@@ -125,40 +163,38 @@ export function Track() {
       const flat = Math.hypot(dir.x, dir.z);
       const yaw = Math.atan2(dir.x, dir.z);
       const pitch = -Math.atan2(dir.y, Math.max(flat, 0.0001));
-      const roll = Math.sin(i * 0.37) * 0.05;
+      const roll = Math.sin(i * TRAIL_CONFIG.rollFrequency) * TRAIL_CONFIG.rollAmount;
 
       outputSegments.push({
-        id: `seg-${i}`,
-        position: [mid.x, mid.y + TRAIL_CENTER_Y_OFFSET, mid.z],
+        position: [mid.x, mid.y + TRAIL_CONFIG.centerYOffset, mid.z],
         rotation: [pitch, yaw, roll],
-        length: length + 0.12,
+        scale: [TRAIL_CONFIG.width, TRAIL_CONFIG.thickness, length + TRAIL_CONFIG.segmentLengthPad],
       });
 
       const progressT = i / lastIndex;
-      const ridgeHeight = 2.8 + progressT * 5.2;
-      const ridgeWidth = 8.5 + progressT * 4.5;
+      const ridgeHeight = TRAIL_CONFIG.ridge.baseHeight + progressT * TRAIL_CONFIG.ridge.growHeight;
+      const ridgeWidth = TRAIL_CONFIG.ridge.baseWidth + progressT * TRAIL_CONFIG.ridge.growWidth;
       outputRidges.push({
-        id: `ridge-${i}`,
-        position: [mid.x, mid.y - ridgeHeight * 0.65, mid.z],
-        rotation: [pitch, yaw, roll * 0.3],
-        scale: [ridgeWidth, ridgeHeight, length + 1.8],
+        position: [mid.x, mid.y - ridgeHeight * TRAIL_CONFIG.ridge.sinkRatio, mid.z],
+        rotation: [pitch, yaw, roll * TRAIL_CONFIG.ridge.rollScale],
+        scale: [ridgeWidth, ridgeHeight, length + TRAIL_CONFIG.ridge.lengthPad],
       });
 
-      if (i % TRAIL_STONE_EVERY === 0) {
+      if (i % TRAIL_CONFIG.stoneEvery === 0) {
         const side = dir.clone().cross(up).normalize();
-        const left = mid.clone().add(side.clone().multiplyScalar(1.55));
-        const right = mid.clone().add(side.multiplyScalar(-1.55));
+        const left = mid.clone().add(side.clone().multiplyScalar(TRAIL_CONFIG.stoneSideOffset));
+        const right = mid.clone().add(side.multiplyScalar(-TRAIL_CONFIG.stoneSideOffset));
         const leftScaleSeed = 0.65 + (i % 3) * 0.08;
         const rightScaleSeed = 0.58 + ((i + 1) % 3) * 0.09;
 
         outputStones.push({
-          id: `stone-l-${i}`,
-          position: [left.x, left.y - 0.45, left.z],
+          position: [left.x, left.y - TRAIL_CONFIG.stoneLeftY, left.z],
+          rotation: [pitch, yaw, 0],
           scale: [leftScaleSeed, leftScaleSeed * 0.8, leftScaleSeed],
         });
         outputStones.push({
-          id: `stone-r-${i}`,
-          position: [right.x, right.y - 0.42, right.z],
+          position: [right.x, right.y - TRAIL_CONFIG.stoneRightY, right.z],
+          rotation: [pitch, yaw, 0],
           scale: [rightScaleSeed, rightScaleSeed * 0.75, rightScaleSeed],
         });
       }
@@ -167,31 +203,26 @@ export function Track() {
     return { segments: outputSegments, stones: outputStones, ridges: outputRidges };
   }, []);
 
+  useLayoutEffect(() => {
+    if (segmentRef.current) applyInstanceTransforms(segmentRef.current, segments);
+    if (stoneRef.current) applyInstanceTransforms(stoneRef.current, stones);
+    if (ridgeRef.current) applyInstanceTransforms(ridgeRef.current, ridges);
+  }, [segments, stones, ridges]);
+
   return (
     <group>
-      {ridges.map((ridge) => (
-        <mesh
-          key={ridge.id}
-          position={ridge.position}
-          rotation={ridge.rotation}
-          scale={ridge.scale}
-        >
-          <boxGeometry args={[1, 1, 1]} />
-          <meshStandardMaterial color="#4f5e4d" roughness={0.98} />
-        </mesh>
-      ))}
-      {segments.map((segment) => (
-        <mesh key={segment.id} position={segment.position} rotation={segment.rotation}>
-          <boxGeometry args={[TRAIL_WIDTH, TRAIL_THICKNESS, segment.length]} />
-          <meshStandardMaterial color="#8a6a47" roughness={0.94} />
-        </mesh>
-      ))}
-      {stones.map((stone) => (
-        <mesh key={stone.id} position={stone.position} scale={stone.scale}>
-          <dodecahedronGeometry args={[1, 0]} />
-          <meshStandardMaterial color="#5e6a72" roughness={0.98} />
-        </mesh>
-      ))}
+      <instancedMesh ref={ridgeRef} args={[undefined, undefined, ridges.length]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="#4f5e4d" roughness={0.98} />
+      </instancedMesh>
+      <instancedMesh ref={segmentRef} args={[undefined, undefined, segments.length]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="#8a6a47" roughness={0.94} />
+      </instancedMesh>
+      <instancedMesh ref={stoneRef} args={[undefined, undefined, stones.length]}>
+        <dodecahedronGeometry args={[1, 0]} />
+        <meshStandardMaterial color="#5e6a72" roughness={0.98} />
+      </instancedMesh>
       <FinishLine />
     </group>
   );

--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -18,6 +18,9 @@ const TRAIL_SAMPLE_COUNT = 200;
 const TRAIL_WIDTH = 2.4;
 const TRAIL_THICKNESS = 0.2;
 const TRAIL_STONE_EVERY = 5;
+const TRAIL_CENTER_Y_OFFSET = 0.08;
+export const TRACK_SURFACE_Y_OFFSET = TRAIL_CENTER_Y_OFFSET + TRAIL_THICKNESS / 2;
+const _surfacePoint = new Vector3();
 
 export const trackCurve = new CatmullRomCurve3(TRACK_POINTS, false, "catmullrom", 0.3);
 
@@ -29,6 +32,10 @@ export function getTrackPoint(progress: number): Vector3 {
 
 export function getTrackPointTo(progress: number, out: Vector3): Vector3 {
   return trackCurve.getPointAt(Math.min(Math.max(progress, 0), 1), out);
+}
+
+export function getTrackSurfaceY(progress: number): number {
+  return getTrackPointTo(progress, _surfacePoint).y + TRACK_SURFACE_Y_OFFSET;
 }
 
 export function getTrackTangent(progress: number): Vector3 {
@@ -122,7 +129,7 @@ export function Track() {
 
       outputSegments.push({
         id: `seg-${i}`,
-        position: [mid.x, mid.y + 0.08, mid.z],
+        position: [mid.x, mid.y + TRAIL_CENTER_Y_OFFSET, mid.z],
         rotation: [pitch, yaw, roll],
         length: length + 0.12,
       });

--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -123,13 +123,25 @@ const _instanceObject = new Object3D();
 
 function applyInstanceTransforms(
   mesh: InstancedMesh,
-  transforms: { position: [number, number, number]; rotation: [number, number, number]; scale: [number, number, number] }[],
+  transforms: {
+    position: [number, number, number];
+    rotation: [number, number, number];
+    scale: [number, number, number];
+  }[],
 ) {
   for (let i = 0; i < transforms.length; i++) {
     const transform = transforms[i];
     if (!transform) continue;
-    _instanceObject.position.set(transform.position[0], transform.position[1], transform.position[2]);
-    _instanceObject.rotation.set(transform.rotation[0], transform.rotation[1], transform.rotation[2]);
+    _instanceObject.position.set(
+      transform.position[0],
+      transform.position[1],
+      transform.position[2],
+    );
+    _instanceObject.rotation.set(
+      transform.rotation[0],
+      transform.rotation[1],
+      transform.rotation[2],
+    );
     _instanceObject.scale.set(transform.scale[0], transform.scale[1], transform.scale[2]);
     _instanceObject.updateMatrix();
     mesh.setMatrixAt(i, _instanceObject.matrix);

--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -1,21 +1,25 @@
 import { useMemo } from "react";
-import { CatmullRomCurve3, Vector3, DoubleSide } from "three";
+import { CatmullRomCurve3, Vector3 } from "three";
 import { FINISH_LINE } from "@/features/mountain-race/constants";
 
 const TRACK_POINTS = [
-  new Vector3(0, 0, 0),
-  new Vector3(10, 5, -20),
-  new Vector3(-5, 15, -50),
-  new Vector3(8, 25, -80),
-  new Vector3(-3, 35, -110),
-  new Vector3(0, 40, -130),
+  new Vector3(0, 0, 6),
+  new Vector3(6, 1.5, -10),
+  new Vector3(-5, 3.5, -24),
+  new Vector3(7.5, 6.5, -40),
+  new Vector3(-7, 9.5, -58),
+  new Vector3(6.5, 13, -78),
+  new Vector3(-6, 16.5, -100),
+  new Vector3(4, 20, -122),
+  new Vector3(0, 24, -142),
 ];
 
-const TUBE_RADIUS = 0.4;
-const TUBE_SEGMENTS = 128;
-const TUBE_RADIAL_SEGMENTS = 8;
+const TRAIL_SAMPLE_COUNT = 200;
+const TRAIL_WIDTH = 2.4;
+const TRAIL_THICKNESS = 0.2;
+const TRAIL_STONE_EVERY = 5;
 
-export const trackCurve = new CatmullRomCurve3(TRACK_POINTS, false, "catmullrom", 0.5);
+export const trackCurve = new CatmullRomCurve3(TRACK_POINTS, false, "catmullrom", 0.3);
 
 export const FINISH_LINE_PROGRESS = FINISH_LINE;
 
@@ -45,9 +49,13 @@ export function getFinishLinePositionTo(out: Vector3): Vector3 {
 
 function FinishLine() {
   const position = useMemo(() => getFinishLinePosition(), []);
+  const yaw = useMemo(() => {
+    const tangent = getTrackTangent(FINISH_LINE_PROGRESS);
+    return Math.atan2(tangent.x, tangent.z);
+  }, []);
 
   return (
-    <group position={position}>
+    <group position={position} rotation={[0, yaw, 0]}>
       <mesh position={[1.5, 2.5, 0]}>
         <boxGeometry args={[0.12, 5, 0.12]} />
         <meshStandardMaterial color="#8b4513" />
@@ -68,18 +76,110 @@ function FinishLine() {
   );
 }
 
+interface TrailSegment {
+  id: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  length: number;
+}
+
+interface TrailStone {
+  id: string;
+  position: [number, number, number];
+  scale: [number, number, number];
+}
+
+interface TrailRidge {
+  id: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: [number, number, number];
+}
+
 export function Track() {
-  const tubeArgs = useMemo(
-    () => [trackCurve, TUBE_SEGMENTS, TUBE_RADIUS, TUBE_RADIAL_SEGMENTS, false] as const,
-    [],
-  );
+  const { segments, stones, ridges } = useMemo(() => {
+    const sampled = trackCurve.getSpacedPoints(TRAIL_SAMPLE_COUNT);
+    const outputSegments: TrailSegment[] = [];
+    const outputStones: TrailStone[] = [];
+    const outputRidges: TrailRidge[] = [];
+    const up = new Vector3(0, 1, 0);
+    const lastIndex = Math.max(sampled.length - 2, 1);
+
+    for (let i = 0; i < sampled.length - 1; i++) {
+      const start = sampled[i];
+      const end = sampled[i + 1];
+      if (!start || !end) continue;
+
+      const dir = end.clone().sub(start);
+      const length = dir.length();
+      if (length < 0.001) continue;
+
+      const mid = start.clone().add(end).multiplyScalar(0.5);
+      const flat = Math.hypot(dir.x, dir.z);
+      const yaw = Math.atan2(dir.x, dir.z);
+      const pitch = -Math.atan2(dir.y, Math.max(flat, 0.0001));
+      const roll = Math.sin(i * 0.37) * 0.05;
+
+      outputSegments.push({
+        id: `seg-${i}`,
+        position: [mid.x, mid.y + 0.08, mid.z],
+        rotation: [pitch, yaw, roll],
+        length: length + 0.12,
+      });
+
+      const progressT = i / lastIndex;
+      const ridgeHeight = 2.8 + progressT * 5.2;
+      const ridgeWidth = 8.5 + progressT * 4.5;
+      outputRidges.push({
+        id: `ridge-${i}`,
+        position: [mid.x, mid.y - ridgeHeight * 0.65, mid.z],
+        rotation: [pitch, yaw, roll * 0.3],
+        scale: [ridgeWidth, ridgeHeight, length + 1.8],
+      });
+
+      if (i % TRAIL_STONE_EVERY === 0) {
+        const side = dir.clone().cross(up).normalize();
+        const left = mid.clone().add(side.clone().multiplyScalar(1.55));
+        const right = mid.clone().add(side.multiplyScalar(-1.55));
+        const leftScaleSeed = 0.65 + ((i % 3) * 0.08);
+        const rightScaleSeed = 0.58 + (((i + 1) % 3) * 0.09);
+
+        outputStones.push({
+          id: `stone-l-${i}`,
+          position: [left.x, left.y - 0.45, left.z],
+          scale: [leftScaleSeed, leftScaleSeed * 0.8, leftScaleSeed],
+        });
+        outputStones.push({
+          id: `stone-r-${i}`,
+          position: [right.x, right.y - 0.42, right.z],
+          scale: [rightScaleSeed, rightScaleSeed * 0.75, rightScaleSeed],
+        });
+      }
+    }
+
+    return { segments: outputSegments, stones: outputStones, ridges: outputRidges };
+  }, []);
 
   return (
     <group>
-      <mesh>
-        <tubeGeometry args={[...tubeArgs]} />
-        <meshStandardMaterial color="#8B7355" roughness={0.9} side={DoubleSide} />
-      </mesh>
+      {ridges.map((ridge) => (
+        <mesh key={ridge.id} position={ridge.position} rotation={ridge.rotation} scale={ridge.scale}>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshStandardMaterial color="#4f5e4d" roughness={0.98} />
+        </mesh>
+      ))}
+      {segments.map((segment) => (
+        <mesh key={segment.id} position={segment.position} rotation={segment.rotation}>
+          <boxGeometry args={[TRAIL_WIDTH, TRAIL_THICKNESS, segment.length]} />
+          <meshStandardMaterial color="#8a6a47" roughness={0.94} />
+        </mesh>
+      ))}
+      {stones.map((stone) => (
+        <mesh key={stone.id} position={stone.position} scale={stone.scale}>
+          <dodecahedronGeometry args={[1, 0]} />
+          <meshStandardMaterial color="#5e6a72" roughness={0.98} />
+        </mesh>
+      ))}
       <FinishLine />
     </group>
   );

--- a/apps/web/src/features/mountain-race/components/Track.tsx
+++ b/apps/web/src/features/mountain-race/components/Track.tsx
@@ -141,8 +141,8 @@ export function Track() {
         const side = dir.clone().cross(up).normalize();
         const left = mid.clone().add(side.clone().multiplyScalar(1.55));
         const right = mid.clone().add(side.multiplyScalar(-1.55));
-        const leftScaleSeed = 0.65 + ((i % 3) * 0.08);
-        const rightScaleSeed = 0.58 + (((i + 1) % 3) * 0.09);
+        const leftScaleSeed = 0.65 + (i % 3) * 0.08;
+        const rightScaleSeed = 0.58 + ((i + 1) % 3) * 0.09;
 
         outputStones.push({
           id: `stone-l-${i}`,
@@ -163,7 +163,12 @@ export function Track() {
   return (
     <group>
       {ridges.map((ridge) => (
-        <mesh key={ridge.id} position={ridge.position} rotation={ridge.rotation} scale={ridge.scale}>
+        <mesh
+          key={ridge.id}
+          position={ridge.position}
+          rotation={ridge.rotation}
+          scale={ridge.scale}
+        >
           <boxGeometry args={[1, 1, 1]} />
           <meshStandardMaterial color="#4f5e4d" roughness={0.98} />
         </mesh>

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -19,9 +19,7 @@ function SceneContent() {
     ? (characters.find((c) => c.id === activeBubble.characterId)?.progress ?? null)
     : null;
   const leaderId = rankings[0];
-  const leaderProgress = leaderId
-    ? (characters.find((c) => c.id === leaderId)?.progress ?? 0)
-    : 0;
+  const leaderProgress = leaderId ? (characters.find((c) => c.id === leaderId)?.progress ?? 0) : 0;
 
   return (
     <>

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -18,11 +18,15 @@ function SceneContent() {
   const bubbleCharProgress = activeBubble
     ? (characters.find((c) => c.id === activeBubble.characterId)?.progress ?? null)
     : null;
+  const leaderId = rankings[0];
+  const leaderProgress = leaderId
+    ? (characters.find((c) => c.id === leaderId)?.progress ?? 0)
+    : 0;
 
   return (
     <>
       <Track />
-      <Environment activeGlobalEvent={activeGlobalEvent} />
+      <Environment activeGlobalEvent={activeGlobalEvent} leaderProgress={leaderProgress} />
       {characters.map((char) => (
         <Character key={char.id} character={char} isFinished={finishedIds.includes(char.id)} />
       ))}


### PR DESCRIPTION
## 요약

- 레이스 씬의 산길이 평지/공중 튜브처럼 보이던 문제를 해소하기 위해 트랙과 환경 렌더링을 함께 튜닝했습니다.
- 산길 가독성(길/지형 분리), 고도감(구간별 나무 밀도), 날씨 연출(비 강도/안개 밀도)을 현재 게임 흐름에 맞춰 조정했습니다.

## 변경 사항

- `Track`를 단순 튜브 경로에서 세그먼트 기반 산길로 전환하고, 길 하부에 ridge 지형을 생성해 산 몸체를 따라가는 느낌을 강화했습니다.
- `Environment`에 선두 진행도 기반 고도 비 연출을 추가하고 비 강도(방울 수/속도/투명도)를 동적으로 조정했습니다.
- 안개를 상태(맑음/비/안개 이벤트)별로 분리해 가시거리와 분위기를 단계화했습니다.
- 나무 배치를 초반/중반/정상 구간으로 나눠 밀도, 크기, 오프셋을 다르게 적용했습니다.
- `RaceScreen`에서 선두 진행도를 계산해 환경 연출 파라미터로 전달했습니다.

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check`
  - [ ] 기타:
- 수동 확인: 로컬 `race` 화면에서 산길/지형/나무/구름/비 연출 확인
- 실행하지 않은 검증과 이유: 없음

## 스크린샷 또는 데모

- 채팅 스레드에 로컬 캡처 2장 첨부(수정 전/후 맥락 확인용)

## 문서 반영

- [x] 문서 변경 없음
- [ ] 관련 문서를 함께 수정함
- [ ] 후속 문서 반영 필요
- 관련 문서: 없음

## 리스크와 후속 작업

- 카메라 각도에 따라 하단 지형 클리핑이 드물게 보일 수 있어, 필요 시 카메라 최소 Y 클램프를 후속으로 적용할 수 있습니다.

Made with [Cursor](https://cursor.com)