### PR TITLE
feat(web): 레이스 자유 카메라 조작 시스템

### DIFF
--- a/apps/web/src/features/mountain-race/components/CameraControls.tsx
+++ b/apps/web/src/features/mountain-race/components/CameraControls.tsx
@@ -70,9 +70,9 @@ export function CameraControls() {
   const activeCharIndex = cameraTarget ? characters.findIndex((c) => c.id === cameraTarget) : -1;
 
   return (
-    <>
+    <div className="pointer-events-auto absolute top-3 left-3 z-30 flex flex-col items-start gap-2">
       {/* control bar */}
-      <div className="pointer-events-auto absolute top-3 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-xl bg-black/55 px-3 py-2 shadow-lg backdrop-blur-md">
+      <div className="flex items-center gap-1.5 rounded-xl bg-black/55 px-3 py-2 shadow-lg backdrop-blur-md">
         <button
           type="button"
           onClick={isFree ? returnToAuto : toggleMode}
@@ -109,56 +109,54 @@ export function CameraControls() {
         })}
       </div>
 
-      {/* guide overlay */}
+      {/* guide overlay / toggle — centered under control bar */}
       {guideVisible ? (
-        <div className="pointer-events-auto absolute top-16 left-1/2 z-30 -translate-x-1/2">
-          <div className="relative rounded-xl bg-black/60 px-4 py-3 shadow-lg backdrop-blur-md">
-            <button
-              type="button"
-              onClick={() => setGuideVisible(false)}
-              className="absolute top-1.5 right-2 text-sm text-white/40 hover:text-white/80"
-              aria-label="가이드 닫기"
-            >
-              ✕
-            </button>
-            <p className="mb-2 text-xs font-bold text-white/90">📷 카메라 조작법</p>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-[0.7rem] leading-relaxed text-white/70">
-              <span>
-                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
-                  1
-                </kbd>
-                ~
-                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
-                  8
-                </kbd>{" "}
-                캐릭터 포커스
-              </span>
-              <span>
-                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
-                  0
-                </kbd>{" "}
-                /{" "}
-                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
-                  Esc
-                </kbd>{" "}
-                자동 시점 복귀
-              </span>
-              <span>🖱️ 드래그 → 회전</span>
-              <span>🖱️ 우클릭 드래그 → 이동</span>
-              <span>🖱️ 스크롤 → 줌 인/아웃</span>
-              <span>📱 핀치 → 줌 / 2핑거 → 이동</span>
-            </div>
+        <div className="relative self-center rounded-xl bg-black/60 px-4 py-3 shadow-lg backdrop-blur-md">
+          <button
+            type="button"
+            onClick={() => setGuideVisible(false)}
+            className="absolute top-1.5 right-2 text-sm text-white/40 hover:text-white/80"
+            aria-label="가이드 닫기"
+          >
+            ✕
+          </button>
+          <p className="mb-2 text-xs font-bold text-white/90">📷 카메라 조작법</p>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-[0.7rem] leading-relaxed text-white/70">
+            <span>
+              <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                1
+              </kbd>
+              ~
+              <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                8
+              </kbd>{" "}
+              캐릭터 포커스
+            </span>
+            <span>
+              <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                0
+              </kbd>{" "}
+              /{" "}
+              <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                Esc
+              </kbd>{" "}
+              자동 시점 복귀
+            </span>
+            <span>🖱️ 드래그 → 회전</span>
+            <span>🖱️ 우클릭 드래그 → 이동</span>
+            <span>🖱️ 스크롤 → 줌 인/아웃</span>
+            <span>📱 핀치 → 줌 / 2핑거 → 이동</span>
           </div>
         </div>
       ) : (
         <button
           type="button"
           onClick={() => setGuideVisible(true)}
-          className="pointer-events-auto absolute top-16 left-1/2 z-30 -translate-x-1/2 rounded-lg bg-black/40 px-2.5 py-1 text-[0.65rem] text-white/40 backdrop-blur-sm transition hover:bg-black/60 hover:text-white/70"
+          className="rounded-lg bg-black/40 px-2.5 py-1 text-[0.65rem] text-white/40 backdrop-blur-sm transition hover:bg-black/60 hover:text-white/70"
         >
           📷 조작법 보기
         </button>
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/features/mountain-race/components/CameraControls.tsx
+++ b/apps/web/src/features/mountain-race/components/CameraControls.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect } from "react";
+import { useGameStore } from "../store/useGameStore";
+
+export function CameraControls() {
+  const characters = useGameStore((s) => s.characters);
+  const cameraMode = useGameStore((s) => s.cameraMode);
+  const cameraTarget = useGameStore((s) => s.cameraTarget);
+  const setCameraMode = useGameStore((s) => s.setCameraMode);
+  const setCameraTarget = useGameStore((s) => s.setCameraTarget);
+  const isRacing = useGameStore((s) => s.isRacing);
+
+  const isFree = cameraMode === "free";
+
+  const toggleMode = useCallback(() => {
+    if (isFree) {
+      setCameraMode("follow");
+      setCameraTarget(null);
+    } else {
+      setCameraMode("free");
+    }
+  }, [isFree, setCameraMode, setCameraTarget]);
+
+  const focusCharacter = useCallback(
+    (index: number) => {
+      const char = characters[index];
+      if (!char) return;
+      if (!isFree) setCameraMode("free");
+      setCameraTarget(char.id);
+    },
+    [characters, isFree, setCameraMode, setCameraTarget],
+  );
+
+  const returnToAuto = useCallback(() => {
+    setCameraMode("follow");
+    setCameraTarget(null);
+  }, [setCameraMode, setCameraTarget]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+      const num = Number(e.key);
+      if (num >= 1 && num <= 8) {
+        e.preventDefault();
+        focusCharacter(num - 1);
+        return;
+      }
+      if (e.key === "0" || e.key === "Escape") {
+        e.preventDefault();
+        returnToAuto();
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [focusCharacter, returnToAuto]);
+
+  if (!isRacing) return null;
+
+  const activeCharIndex = cameraTarget ? characters.findIndex((c) => c.id === cameraTarget) : -1;
+
+  return (
+    <div className="pointer-events-auto absolute bottom-14 left-3 z-30 flex flex-col gap-2 md:bottom-4">
+      {/* mode toggle */}
+      <button
+        type="button"
+        onClick={toggleMode}
+        className="flex items-center gap-1.5 rounded-lg bg-black/50 px-3 py-2 text-xs font-semibold text-white backdrop-blur-sm transition hover:bg-black/70 active:scale-95"
+        aria-label={isFree ? "자동 추적 모드로 전환" : "자유 시점 모드로 전환"}
+      >
+        <span className="text-sm">{isFree ? "🎥" : "🕹️"}</span>
+        <span>{isFree ? "자동 추적" : "자유 시점"}</span>
+        <kbd className="ml-1 rounded bg-white/15 px-1 py-0.5 text-[0.6rem] text-white/50">
+          {isFree ? "0" : ""}
+        </kbd>
+      </button>
+
+      {/* character selector */}
+      <div className="flex gap-1 rounded-lg bg-black/50 px-2 py-1.5 backdrop-blur-sm">
+        {characters.map((char, idx) => {
+          const isActive = idx === activeCharIndex;
+          return (
+            <button
+              key={char.id}
+              type="button"
+              onClick={() => focusCharacter(idx)}
+              className={`relative flex h-7 w-7 items-center justify-center rounded-full border-2 transition-all hover:scale-110 active:scale-95 ${
+                isActive
+                  ? "border-white shadow-[0_0_8px_rgba(255,255,255,0.4)]"
+                  : "border-transparent hover:border-white/40"
+              }`}
+              style={{ backgroundColor: char.color.jacket }}
+              aria-label={`${char.name} 카메라 포커스 (${idx + 1})`}
+              title={`${char.name} (${idx + 1})`}
+            >
+              <span className="text-[0.5rem] font-bold text-white drop-shadow-sm">{idx + 1}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* hint */}
+      {isFree ? (
+        <p className="max-w-[200px] text-[0.55rem] leading-tight text-white/40">
+          드래그=회전 · 우클릭/2핑거=이동 · 스크롤=줌 · 1~8=캐릭터 · 0/Esc=자동
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/CameraControls.tsx
+++ b/apps/web/src/features/mountain-race/components/CameraControls.tsx
@@ -63,50 +63,51 @@ export function CameraControls() {
   const activeCharIndex = cameraTarget ? characters.findIndex((c) => c.id === cameraTarget) : -1;
 
   return (
-    <div className="pointer-events-auto absolute bottom-14 left-3 z-30 flex flex-col gap-2 md:bottom-4">
-      {/* mode toggle */}
+    <div className="pointer-events-auto absolute top-3 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-xl bg-black/50 px-2.5 py-1.5 backdrop-blur-sm">
+      {/* auto follow */}
       <button
         type="button"
-        onClick={toggleMode}
-        className="flex items-center gap-1.5 rounded-lg bg-black/50 px-3 py-2 text-xs font-semibold text-white backdrop-blur-sm transition hover:bg-black/70 active:scale-95"
-        aria-label={isFree ? "자동 추적 모드로 전환" : "자유 시점 모드로 전환"}
+        onClick={isFree ? returnToAuto : toggleMode}
+        className={`flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[0.65rem] font-semibold transition active:scale-95 ${
+          !isFree ? "bg-white/20 text-white" : "text-white/50 hover:bg-white/10 hover:text-white/80"
+        }`}
+        aria-label="자동 추적"
+        title="자동 추적 (0)"
       >
-        <span className="text-sm">{isFree ? "🎥" : "🕹️"}</span>
-        <span>{isFree ? "자동 추적" : "자유 시점"}</span>
-        <kbd className="ml-1 rounded bg-white/15 px-1 py-0.5 text-[0.6rem] text-white/50">
-          {isFree ? "0" : ""}
-        </kbd>
+        <span className="text-xs">🎥</span>
+        <span className="hidden sm:inline">자동</span>
       </button>
 
-      {/* character selector */}
-      <div className="flex gap-1 rounded-lg bg-black/50 px-2 py-1.5 backdrop-blur-sm">
-        {characters.map((char, idx) => {
-          const isActive = idx === activeCharIndex;
-          return (
-            <button
-              key={char.id}
-              type="button"
-              onClick={() => focusCharacter(idx)}
-              className={`relative flex h-7 w-7 items-center justify-center rounded-full border-2 transition-all hover:scale-110 active:scale-95 ${
-                isActive
-                  ? "border-white shadow-[0_0_8px_rgba(255,255,255,0.4)]"
-                  : "border-transparent hover:border-white/40"
-              }`}
-              style={{ backgroundColor: char.color.jacket }}
-              aria-label={`${char.name} 카메라 포커스 (${idx + 1})`}
-              title={`${char.name} (${idx + 1})`}
-            >
-              <span className="text-[0.5rem] font-bold text-white drop-shadow-sm">{idx + 1}</span>
-            </button>
-          );
-        })}
-      </div>
+      <span className="h-4 w-px bg-white/20" />
 
-      {/* hint */}
+      {/* character buttons */}
+      {characters.map((char, idx) => {
+        const isActive = idx === activeCharIndex;
+        return (
+          <button
+            key={char.id}
+            type="button"
+            onClick={() => focusCharacter(idx)}
+            className={`flex h-6 w-6 items-center justify-center rounded-full border-2 text-[0.55rem] font-bold text-white transition-all hover:scale-110 active:scale-95 ${
+              isActive
+                ? "border-white shadow-[0_0_6px_rgba(255,255,255,0.4)]"
+                : "border-white/20 hover:border-white/50"
+            }`}
+            style={{ backgroundColor: char.color.jacket }}
+            aria-label={`${char.name} 카메라 포커스 (${idx + 1})`}
+            title={`${char.name} (${idx + 1})`}
+          >
+            {idx + 1}
+          </button>
+        );
+      })}
+
+      {/* free mode hint */}
       {isFree ? (
-        <p className="max-w-[200px] text-[0.55rem] leading-tight text-white/40">
-          드래그=회전 · 우클릭/2핑거=이동 · 스크롤=줌 · 1~8=캐릭터 · 0/Esc=자동
-        </p>
+        <>
+          <span className="h-4 w-px bg-white/20" />
+          <span className="text-[0.5rem] text-white/40">드래그=회전 · 스크롤=줌</span>
+        </>
       ) : null}
     </div>
   );

--- a/apps/web/src/features/mountain-race/components/CameraControls.tsx
+++ b/apps/web/src/features/mountain-race/components/CameraControls.tsx
@@ -36,6 +36,8 @@ export function CameraControls() {
   }, [setCameraMode, setCameraTarget]);
 
   useEffect(() => {
+    if (!isRacing) return;
+
     function onKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
 
@@ -54,7 +56,7 @@ export function CameraControls() {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [focusCharacter, returnToAuto]);
+  }, [isRacing, focusCharacter, returnToAuto]);
 
   if (!isRacing) return null;
 

--- a/apps/web/src/features/mountain-race/components/CameraControls.tsx
+++ b/apps/web/src/features/mountain-race/components/CameraControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useGameStore } from "../store/useGameStore";
 
 export function CameraControls() {
@@ -8,6 +8,7 @@ export function CameraControls() {
   const setCameraMode = useGameStore((s) => s.setCameraMode);
   const setCameraTarget = useGameStore((s) => s.setCameraTarget);
   const isRacing = useGameStore((s) => s.isRacing);
+  const [guideVisible, setGuideVisible] = useState(true);
 
   const isFree = cameraMode === "free";
 
@@ -58,57 +59,106 @@ export function CameraControls() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isRacing, focusCharacter, returnToAuto]);
 
+  useEffect(() => {
+    if (!isRacing) return;
+    const timer = setTimeout(() => setGuideVisible(false), 8000);
+    return () => clearTimeout(timer);
+  }, [isRacing]);
+
   if (!isRacing) return null;
 
   const activeCharIndex = cameraTarget ? characters.findIndex((c) => c.id === cameraTarget) : -1;
 
   return (
-    <div className="pointer-events-auto absolute top-3 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-xl bg-black/50 px-2.5 py-1.5 backdrop-blur-sm">
-      {/* auto follow */}
-      <button
-        type="button"
-        onClick={isFree ? returnToAuto : toggleMode}
-        className={`flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[0.65rem] font-semibold transition active:scale-95 ${
-          !isFree ? "bg-white/20 text-white" : "text-white/50 hover:bg-white/10 hover:text-white/80"
-        }`}
-        aria-label="자동 추적"
-        title="자동 추적 (0)"
-      >
-        <span className="text-xs">🎥</span>
-        <span className="hidden sm:inline">자동</span>
-      </button>
+    <>
+      {/* control bar */}
+      <div className="pointer-events-auto absolute top-3 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-xl bg-black/55 px-3 py-2 shadow-lg backdrop-blur-md">
+        <button
+          type="button"
+          onClick={isFree ? returnToAuto : toggleMode}
+          className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold transition active:scale-95 ${
+            !isFree ? "bg-white/25 text-white" : "text-white/60 hover:bg-white/10 hover:text-white"
+          }`}
+          aria-label="자동 추적"
+          title="자동 추적 (0 또는 Esc)"
+        >
+          🎥 자동
+        </button>
 
-      <span className="h-4 w-px bg-white/20" />
+        <span className="h-5 w-px bg-white/25" />
 
-      {/* character buttons */}
-      {characters.map((char, idx) => {
-        const isActive = idx === activeCharIndex;
-        return (
-          <button
-            key={char.id}
-            type="button"
-            onClick={() => focusCharacter(idx)}
-            className={`flex h-6 w-6 items-center justify-center rounded-full border-2 text-[0.55rem] font-bold text-white transition-all hover:scale-110 active:scale-95 ${
-              isActive
-                ? "border-white shadow-[0_0_6px_rgba(255,255,255,0.4)]"
-                : "border-white/20 hover:border-white/50"
-            }`}
-            style={{ backgroundColor: char.color.jacket }}
-            aria-label={`${char.name} 카메라 포커스 (${idx + 1})`}
-            title={`${char.name} (${idx + 1})`}
-          >
-            {idx + 1}
-          </button>
-        );
-      })}
+        {characters.map((char, idx) => {
+          const isActive = idx === activeCharIndex;
+          return (
+            <button
+              key={char.id}
+              type="button"
+              onClick={() => focusCharacter(idx)}
+              className={`flex h-7 w-7 items-center justify-center rounded-full border-2 text-xs font-bold text-white transition-all hover:scale-110 active:scale-95 ${
+                isActive
+                  ? "border-white shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+                  : "border-white/25 hover:border-white/60"
+              }`}
+              style={{ backgroundColor: char.color.jacket }}
+              aria-label={`${char.name} 카메라 포커스 (${idx + 1})`}
+              title={`${char.name} (${idx + 1})`}
+            >
+              {idx + 1}
+            </button>
+          );
+        })}
+      </div>
 
-      {/* free mode hint */}
-      {isFree ? (
-        <>
-          <span className="h-4 w-px bg-white/20" />
-          <span className="text-[0.5rem] text-white/40">드래그=회전 · 스크롤=줌</span>
-        </>
-      ) : null}
-    </div>
+      {/* guide overlay */}
+      {guideVisible ? (
+        <div className="pointer-events-auto absolute top-16 left-1/2 z-30 -translate-x-1/2">
+          <div className="relative rounded-xl bg-black/60 px-4 py-3 shadow-lg backdrop-blur-md">
+            <button
+              type="button"
+              onClick={() => setGuideVisible(false)}
+              className="absolute top-1.5 right-2 text-sm text-white/40 hover:text-white/80"
+              aria-label="가이드 닫기"
+            >
+              ✕
+            </button>
+            <p className="mb-2 text-xs font-bold text-white/90">📷 카메라 조작법</p>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-[0.7rem] leading-relaxed text-white/70">
+              <span>
+                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                  1
+                </kbd>
+                ~
+                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                  8
+                </kbd>{" "}
+                캐릭터 포커스
+              </span>
+              <span>
+                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                  0
+                </kbd>{" "}
+                /{" "}
+                <kbd className="rounded bg-white/15 px-1 py-0.5 text-[0.6rem] font-semibold text-white/90">
+                  Esc
+                </kbd>{" "}
+                자동 시점 복귀
+              </span>
+              <span>🖱️ 드래그 → 회전</span>
+              <span>🖱️ 우클릭 드래그 → 이동</span>
+              <span>🖱️ 스크롤 → 줌 인/아웃</span>
+              <span>📱 핀치 → 줌 / 2핑거 → 이동</span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setGuideVisible(true)}
+          className="pointer-events-auto absolute top-16 left-1/2 z-30 -translate-x-1/2 rounded-lg bg-black/40 px-2.5 py-1 text-[0.65rem] text-white/40 backdrop-blur-sm transition hover:bg-black/60 hover:text-white/70"
+        >
+          📷 조작법 보기
+        </button>
+      )}
+    </>
   );
 }

--- a/apps/web/src/features/mountain-race/components/Character.tsx
+++ b/apps/web/src/features/mountain-race/components/Character.tsx
@@ -158,10 +158,16 @@ function Head({
         />
       </mesh>
       {texture ? (
-        <mesh position={[0, 0, 0.22]} rotation={[0, 0, 0]}>
-          <circleGeometry args={[0.18, 24]} />
-          <meshBasicMaterial map={texture} transparent />
-        </mesh>
+        <group position={[0, 0.02, 0.26]}>
+          <mesh>
+            <circleGeometry args={[0.2, 24]} />
+            <meshBasicMaterial color="#ffffff" />
+          </mesh>
+          <mesh position={[0, 0, 0.001]}>
+            <circleGeometry args={[0.17, 24]} />
+            <meshBasicMaterial map={texture} />
+          </mesh>
+        </group>
       ) : null}
     </group>
   );

--- a/apps/web/src/features/mountain-race/components/Character.tsx
+++ b/apps/web/src/features/mountain-race/components/Character.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react";
+import { useRef, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Html } from "@react-three/drei";
 import type { Group } from "three";
-import { Vector3 } from "three";
+import { Vector3, TextureLoader, SRGBColorSpace } from "three";
 import type { Character as CharacterType } from "@/features/mountain-race/types";
 import { getTrackPointTo, getTrackSurfaceY, getTrackTangentTo } from "./Track";
 
@@ -20,7 +20,7 @@ export function Character({ character, isFinished }: CharacterProps) {
   const groupRef = useRef<Group>(null);
   const phaseRef = useRef(0);
 
-  const { color, status, name, progress } = character;
+  const { color, status, name, progress, faceImage } = character;
   const canAnimate = status !== "stunned" && !isFinished;
   const animSpeed = getAnimationSpeed(status);
 
@@ -52,7 +52,7 @@ export function Character({ character, isFinished }: CharacterProps) {
     <group ref={groupRef} rotation={[0, 0, tiltZ]}>
       <NameLabel name={name} />
       <Hat color={color.buff} />
-      <Head emissive={emissive} />
+      <Head emissive={emissive} faceImage={faceImage} />
       <Buff color={color.buff} />
       <Torso color={color.jacket} emissive={emissive} />
       <Belly color={color.inner} />
@@ -133,16 +133,37 @@ function Hat({ color }: { color: string }) {
   );
 }
 
-function Head({ emissive }: { emissive: { color: string; intensity: number } }) {
+function Head({
+  emissive,
+  faceImage,
+}: {
+  emissive: { color: string; intensity: number };
+  faceImage: string | null;
+}) {
+  const texture = useMemo(() => {
+    if (!faceImage?.startsWith("data:image/")) return null;
+    const tex = new TextureLoader().load(faceImage);
+    tex.colorSpace = SRGBColorSpace;
+    return tex;
+  }, [faceImage]);
+
   return (
-    <mesh position={[0, 1.55, 0]}>
-      <sphereGeometry args={[0.25, 12, 10]} />
-      <meshStandardMaterial
-        color="#ffe0bd"
-        emissive={emissive.color}
-        emissiveIntensity={emissive.intensity}
-      />
-    </mesh>
+    <group position={[0, 1.55, 0]}>
+      <mesh>
+        <sphereGeometry args={[0.25, 12, 10]} />
+        <meshStandardMaterial
+          color="#ffe0bd"
+          emissive={emissive.color}
+          emissiveIntensity={emissive.intensity}
+        />
+      </mesh>
+      {texture ? (
+        <mesh position={[0, 0, 0.22]} rotation={[0, 0, 0]}>
+          <circleGeometry args={[0.18, 24]} />
+          <meshBasicMaterial map={texture} transparent />
+        </mesh>
+      ) : null}
+    </group>
   );
 }
 

--- a/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
+++ b/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { markResultReady } from "@/features/mountain-race/app";
 import { useGameStore } from "@/features/mountain-race/store";
+import { CameraControls } from "./CameraControls";
 import { HUD } from "./HUD";
 import { EventAlert } from "./EventAlert";
 import { EventLog } from "./EventLog";
@@ -21,6 +22,7 @@ export function InGameOverlaySlot() {
       <HUD />
       <EventAlert />
       <EventLog />
+      <CameraControls />
     </aside>
   );
 }

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -1,10 +1,49 @@
+import { useRef, useEffect, type ElementRef } from "react";
 import { Canvas } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { Vector3 } from "three";
 import { useGameStore } from "@/features/mountain-race/store";
 import { Track } from "@/features/mountain-race/components/Track";
 import { Character } from "@/features/mountain-race/components/Character";
 import { Environment } from "@/features/mountain-race/components/Environment";
 import { SpeechBubble } from "@/features/mountain-race/components/SpeechBubble";
-import { CameraSystem } from "@/features/mountain-race/systems";
+import { CameraSystem, getTargetTrackPosition } from "@/features/mountain-race/systems";
+
+const _focusPos = new Vector3();
+
+function FreeOrbitControls() {
+  const controlsRef = useRef<ElementRef<typeof OrbitControls>>(null);
+  const characters = useGameStore((s) => s.characters);
+  const rankings = useGameStore((s) => s.rankings);
+  const cameraTarget = useGameStore((s) => s.cameraTarget);
+
+  useEffect(() => {
+    const controls = controlsRef.current;
+    if (!controls || !cameraTarget) return;
+
+    const ok = getTargetTrackPosition(characters, rankings, cameraTarget, _focusPos);
+    if (!ok) return;
+
+    controls.target.copy(_focusPos);
+    controls.update();
+  }, [cameraTarget, characters, rankings]);
+
+  return (
+    <OrbitControls
+      ref={controlsRef}
+      enableDamping
+      dampingFactor={0.12}
+      minDistance={5}
+      maxDistance={80}
+      maxPolarAngle={Math.PI * 0.85}
+      enablePan
+      panSpeed={0.8}
+      rotateSpeed={0.6}
+      zoomSpeed={1.0}
+      makeDefault
+    />
+  );
+}
 
 function SceneContent() {
   const characters = useGameStore((s) => s.characters);
@@ -35,6 +74,7 @@ function SceneContent() {
         characters={characters}
         rankings={rankings}
       />
+      {cameraMode === "free" ? <FreeOrbitControls /> : null}
     </>
   );
 }

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -1,5 +1,5 @@
-import { useRef, useEffect, type ElementRef } from "react";
-import { Canvas } from "@react-three/fiber";
+import { useRef, type ElementRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { Vector3 } from "three";
 import { useGameStore } from "@/features/mountain-race/store";
@@ -13,20 +13,27 @@ const _focusPos = new Vector3();
 
 function FreeOrbitControls() {
   const controlsRef = useRef<ElementRef<typeof OrbitControls>>(null);
-  const characters = useGameStore((s) => s.characters);
-  const rankings = useGameStore((s) => s.rankings);
-  const cameraTarget = useGameStore((s) => s.cameraTarget);
+  const prevTargetRef = useRef<string | null | undefined>(undefined);
 
-  useEffect(() => {
+  useFrame(() => {
     const controls = controlsRef.current;
     if (!controls) return;
+
+    const { cameraTarget, characters, rankings } = useGameStore.getState();
 
     const ok = getTargetTrackPosition(characters, rankings, cameraTarget, _focusPos);
     if (!ok) return;
 
-    controls.target.copy(_focusPos);
-    controls.update();
-  }, [cameraTarget, characters, rankings]);
+    const isFirstFrame = prevTargetRef.current === undefined;
+    const targetChanged = cameraTarget !== prevTargetRef.current;
+    prevTargetRef.current = cameraTarget;
+
+    if (isFirstFrame || targetChanged) {
+      controls.target.copy(_focusPos);
+    } else if (cameraTarget) {
+      controls.target.lerp(_focusPos, 0.05);
+    }
+  });
 
   return (
     <OrbitControls

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -19,7 +19,7 @@ function FreeOrbitControls() {
 
   useEffect(() => {
     const controls = controlsRef.current;
-    if (!controls || !cameraTarget) return;
+    if (!controls) return;
 
     const ok = getTargetTrackPosition(characters, rankings, cameraTarget, _focusPos);
     if (!ok) return;

--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -351,4 +351,14 @@ export const useGameStore = create<GameState>((set, get) => ({
   pushLog: (log: EventLog) => {
     set((state) => ({ eventLogs: [...state.eventLogs, log] }));
   },
+
+  // ── Camera ──────────────────────────────────────────────────────────────
+
+  setCameraMode: (mode: CameraMode) => {
+    set({ cameraMode: mode });
+  },
+
+  setCameraTarget: (id: string | null) => {
+    set({ cameraTarget: id });
+  },
 }));

--- a/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
+++ b/apps/web/src/features/mountain-race/systems/CameraSystem.tsx
@@ -19,7 +19,7 @@ interface ModeConfig {
   lookAhead: number;
 }
 
-const MODE_CONFIG: Record<CameraMode, ModeConfig> = {
+const MODE_CONFIG: Record<Exclude<CameraMode, "free">, ModeConfig> = {
   follow: { height: 8, distance: 15, side: 0, lookAhead: 5 },
   event_zoom: { height: 4, distance: 8, side: 4, lookAhead: 0 },
   slowmo: { height: 6, distance: 12, side: 2, lookAhead: 3 },
@@ -40,6 +40,18 @@ interface CameraSystemProps {
   rankings: string[];
 }
 
+export function getTargetTrackPosition(
+  characters: Character[],
+  rankings: string[],
+  cameraTarget: string | null,
+  out: Vector3,
+): boolean {
+  const target = resolveTarget(characters, rankings, cameraTarget);
+  if (!target) return false;
+  getTrackPointTo(target.progress, out);
+  return true;
+}
+
 export function CameraSystem({
   cameraMode,
   cameraTarget,
@@ -53,6 +65,11 @@ export function CameraSystem({
   const transitionStart = useRef(Number.NEGATIVE_INFINITY);
 
   useFrame(() => {
+    if (cameraMode === "free") {
+      prevMode.current = "free";
+      return;
+    }
+
     if (cameraMode !== prevMode.current) {
       transitionStart.current = performance.now();
       prevMode.current = cameraMode;

--- a/apps/web/src/features/mountain-race/systems/index.ts
+++ b/apps/web/src/features/mountain-race/systems/index.ts
@@ -1,4 +1,4 @@
-export { CameraSystem } from "./CameraSystem";
+export { CameraSystem, getTargetTrackPosition } from "./CameraSystem";
 export { initDialogueScheduler, processDialogues, resetDialogueScheduler } from "./DialogueSystem";
 export type { DialogueTickInput, DialogueTickResult } from "./DialogueSystem";
 export { initEventScheduler, processEvents, resetEventScheduler } from "./EventSystem";

--- a/apps/web/src/features/mountain-race/types/index.ts
+++ b/apps/web/src/features/mountain-race/types/index.ts
@@ -70,7 +70,7 @@ export interface EventLog {
 
 // ── Camera ─────────────────────────────────────────────────────────────────
 
-export type CameraMode = "follow" | "event_zoom" | "slowmo" | "shake" | "finish";
+export type CameraMode = "follow" | "event_zoom" | "slowmo" | "shake" | "finish" | "free";
 
 // ── Speech Bubble ──────────────────────────────────────────────────────────
 
@@ -126,4 +126,6 @@ export interface GameState {
   // ── Camera ───────────────────────────────────────────────────────────────
   cameraMode: CameraMode;
   cameraTarget: string | null;
+  setCameraMode: (mode: CameraMode) => void;
+  setCameraTarget: (id: string | null) => void;
 }


### PR DESCRIPTION
## 요약

레이스 중 카메라를 자유롭게 조작하는 자유 시점 모드, 키보드 1~8 캐릭터 포커스, 업로드한 얼굴 이미지 렌더링을 추가합니다.

## 변경 사항

### 카메라 자유 조작 시스템
- **`types/index.ts`**: `CameraMode`에 `"free"` 추가, `setCameraMode`/`setCameraTarget` 액션 타입
- **`store/useGameStore.ts`**: `setCameraMode(mode)`, `setCameraTarget(id)` 액션 구현
- **`systems/CameraSystem.tsx`**: `free` 모드 시 lerp/lookAt 스킵, `getTargetTrackPosition` export
- **`screens/RaceScreen.tsx`**: drei `OrbitControls` 조건부 렌더링, 캐릭터 포커스 시 target 동기화
- **`components/CameraControls.tsx`** (신규): 좌측 상단 flex column 컨트롤 바 + 가이드 오버레이
- **`components/InGameOverlaySlot.tsx`**: `<CameraControls />` 삽입

### 자유 시점 드래그 버그 수정
- **`screens/RaceScreen.tsx`**: `FreeOrbitControls`의 `useEffect` → `useFrame` 전환
  - 기존: `characters`/`rankings` Zustand 구독 → 매 프레임 리렌더 + `controls.target.copy()` + `controls.update()` 반복 → 사용자 드래그 입력과 충돌
  - 수정: `useFrame` 내에서 `useGameStore.getState()`로 직접 읽기 → 리렌더 없음, 타겟 변경 시에만 snap, 캐릭터 추적 시 lerp, 자유 모드 시 target 미변경으로 드래그/줌/회전 정상 동작

### 카메라 컨트롤 위치 수정
- 기존 상단 중앙 → **좌측 상단** flex column으로 이동 (카운트다운 UI와 위치 충돌 해소)
- 컨트롤 바 아래에 가이드/토글이 자연스럽게 배치 (gap-2)

### 얼굴 이미지 렌더링 버그 수정
- **`components/Character.tsx`**: `Head`에 `faceImage` prop 추가, data-URL을 TextureLoader로 로드하여 머리 앞면에 원형 텍스처 + 흰색 테두리 렌더링

### 카메라 가이드 UI
- 좌측 상단 컨트롤 바: 🎥 자동 버튼 + 캐릭터 컬러 번호 버튼 (1~N) 한 줄 배치
- 가이드 패널: 2열 그리드, kbd 스타일 단축키, 마우스/터치 조작법 포함
- `0`/`Esc` 자동 시점 복귀 안내 포함
- 8초 후 자동 숨김, `📷 조작법 보기`로 재표시 가능

## 조작법

| 입력 | 동작 |
|------|------|
| 좌클릭 드래그 / 1-finger | 카메라 회전 |
| 우클릭 드래그 / 2-finger 드래그 | 카메라 이동 (pan) |
| 스크롤 / pinch | 줌 인/아웃 |
| 키보드 `1`~`8` | 해당 캐릭터 포커스 |
| 키보드 `0` / `Esc` | 자동 추적 모드 복귀 |
| 상단 🎥 자동 버튼 | 자동 추적 전환 |

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (pre-push hook — lint, format:check, typecheck, build 모두 통과)
- 수동 확인: 로컬 dev 서버에서 자유 시점 드래그/회전/줌, 캐릭터 포커스, 자동 복귀, 얼굴 이미지 표시, 카운트다운 UI 비충돌 확인 필요
- 실행하지 않은 검증과 이유: E2E 테스트 미실행 — 프로젝트에 E2E 프레임워크 미구성

## 스크린샷 또는 데모

시각적 변경이 크므로 머지 전 로컬에서 레이스 화면 확인을 권장합니다.

## 문서 반영

- [x] 문서 변경 없음

## 리스크와 후속 작업

- `FreeOrbitControls` 내부에서 `useGameStore.getState()` 직접 호출 — React 리렌더 사이클 밖에서 상태를 읽으므로 성능은 좋지만, 상태 구조 변경 시 주의 필요
- `Character.tsx` 얼굴 텍스처는 data-URL 기반 — 캐릭터 수가 많아지면 메모리 사용량 모니터링 필요
- 카메라 가이드 텍스트는 한국어 고정 — 다국어 지원 시 i18n 대응 필요