### PR TITLE
feat(web): replace speech bubble with smoke-dissolve dialogue UI

### DIFF
--- a/apps/web/src/features/mountain-race/components/SpeechBubble.tsx
+++ b/apps/web/src/features/mountain-race/components/SpeechBubble.tsx
@@ -1,17 +1,18 @@
 import { Html } from "@react-three/drei";
 import { useRef, useEffect, useState } from "react";
 import type { ActiveBubble } from "@/features/mountain-race/types";
+import { DIALOGUE_DISPLAY_TIME_MS } from "@/features/mountain-race/constants";
 import { getTrackPoint } from "./Track";
 
 const BUBBLE_Y_OFFSET = 3.0;
-const DURATION_MS = 3000;
+const ANIMATION_DURATION_MS = Math.round(DIALOGUE_DISPLAY_TIME_MS * 1.5);
 
 const KEYFRAMES = `
 @keyframes textLife {
-  0%   { opacity: 0; transform: translateY(10px);    filter: blur(3px); }
-  8%   { opacity: 1; transform: translateY(0);        filter: blur(0px); }
-  35%  { opacity: 1; transform: translateY(0);         filter: blur(0px); }
-  100% { opacity: 0; transform: translateY(-280px);    filter: blur(5px); }
+  0%   { opacity: 0; transform: translateY(10px); }
+  8%   { opacity: 1; transform: translateY(0); }
+  35%  { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-280px); }
 }
 
 @keyframes glowLife {
@@ -29,9 +30,35 @@ const KEYFRAMES = `
 @keyframes wispMid {
   50%  { opacity: var(--peak, 0.35); }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes textLife {
+    0%   { opacity: 0; transform: none; }
+    8%   { opacity: 1; transform: none; }
+    35%  { opacity: 1; transform: none; }
+    100% { opacity: 0; transform: none; }
+  }
+  @keyframes glowLife { 0%, 100% { opacity: 0; transform: none; } }
+  @keyframes wisp     { 0%, 100% { opacity: 0; transform: none; } }
+  @keyframes wispMid  { 50% { opacity: 0; } }
+}
 `;
 
+const STYLE_ID = "speech-bubble-keyframes";
+
+function ensureKeyframes(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = KEYFRAMES;
+  document.head.appendChild(style);
+}
+
+ensureKeyframes();
+
 interface WispConfig {
+  id: string;
   ex: number;
   ey: number;
   es: number;
@@ -45,6 +72,7 @@ interface WispConfig {
 
 const WISPS: WispConfig[] = [
   {
+    id: "w0",
     ex: -120,
     ey: -220,
     es: 3.2,
@@ -56,6 +84,7 @@ const WISPS: WispConfig[] = [
     rgb: "200,215,245",
   },
   {
+    id: "w1",
     ex: 110,
     ey: -250,
     es: 3.5,
@@ -67,6 +96,7 @@ const WISPS: WispConfig[] = [
     rgb: "190,208,240",
   },
   {
+    id: "w2",
     ex: 15,
     ey: -290,
     es: 3.8,
@@ -78,6 +108,7 @@ const WISPS: WispConfig[] = [
     rgb: "180,200,235",
   },
   {
+    id: "w3",
     ex: -95,
     ey: -260,
     es: 3.0,
@@ -89,6 +120,7 @@ const WISPS: WispConfig[] = [
     rgb: "195,210,240",
   },
   {
+    id: "w4",
     ex: 130,
     ey: -200,
     es: 3.2,
@@ -100,6 +132,7 @@ const WISPS: WispConfig[] = [
     rgb: "210,220,248",
   },
   {
+    id: "w5",
     ex: -40,
     ey: -310,
     es: 3.5,
@@ -111,6 +144,7 @@ const WISPS: WispConfig[] = [
     rgb: "185,205,240",
   },
   {
+    id: "w6",
     ex: 75,
     ey: -270,
     es: 3.0,
@@ -134,6 +168,10 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    ensureKeyframes();
+  }, []);
+
+  useEffect(() => {
     if (!activeBubble) return;
 
     const key = `${activeBubble.characterId}-${activeBubble.endTime}`;
@@ -149,7 +187,7 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
     timerRef.current = setTimeout(() => {
       setVisibleBubble(null);
       prevKeyRef.current = null;
-    }, DURATION_MS + 50);
+    }, ANIMATION_DURATION_MS + 50);
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
@@ -159,15 +197,13 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
   if (!visibleBubble || characterProgress === null) return null;
 
   const anchorPos = getTrackPoint(characterProgress);
-  const dur = `${DURATION_MS}ms`;
-  const dissolveDelay = DURATION_MS * 0.33;
-  const wispDur = DURATION_MS * 0.67;
+  const dur = `${ANIMATION_DURATION_MS}ms`;
+  const dissolveDelay = ANIMATION_DURATION_MS * 0.33;
+  const wispDur = ANIMATION_DURATION_MS * 0.67;
 
   return (
     <group position={[anchorPos.x, anchorPos.y + BUBBLE_Y_OFFSET, anchorPos.z]}>
       <Html center distanceFactor={12} zIndexRange={[1, 0]} style={{ pointerEvents: "none" }}>
-        <style>{KEYFRAMES}</style>
-
         <div
           style={{
             position: "relative",
@@ -179,7 +215,7 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
             userSelect: "none",
           }}
         >
-          {/* Ambient glow — drifts upward with text */}
+          {/* Ambient glow */}
           <div
             style={{
               position: "absolute",
@@ -193,10 +229,10 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
             }}
           />
 
-          {/* Smoke wisps — drift far upward during dissolve */}
+          {/* Smoke wisps */}
           {WISPS.map((w) => (
             <div
-              key={`${w.left}-${w.top}`}
+              key={w.id}
               style={{
                 position: "absolute",
                 left: w.left,
@@ -239,7 +275,7 @@ export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubblePr
               overflowWrap: "anywhere",
               letterSpacing: "0.02em",
               animation: `textLife ${dur} ease-in-out forwards`,
-              willChange: "opacity, transform, filter",
+              willChange: "opacity, transform",
             }}
           >
             {visibleBubble.text}

--- a/apps/web/src/features/mountain-race/components/SpeechBubble.tsx
+++ b/apps/web/src/features/mountain-race/components/SpeechBubble.tsx
@@ -1,8 +1,127 @@
 import { Html } from "@react-three/drei";
+import { useRef, useEffect, useState } from "react";
 import type { ActiveBubble } from "@/features/mountain-race/types";
 import { getTrackPoint } from "./Track";
 
 const BUBBLE_Y_OFFSET = 3.0;
+const DURATION_MS = 3000;
+
+const KEYFRAMES = `
+@keyframes textLife {
+  0%   { opacity: 0; transform: translateY(10px);    filter: blur(3px); }
+  8%   { opacity: 1; transform: translateY(0);        filter: blur(0px); }
+  35%  { opacity: 1; transform: translateY(0);         filter: blur(0px); }
+  100% { opacity: 0; transform: translateY(-280px);    filter: blur(5px); }
+}
+
+@keyframes glowLife {
+  0%   { opacity: 0;   transform: scale(0.9); }
+  8%   { opacity: 0.5; transform: scale(1); }
+  35%  { opacity: 0.4; transform: scale(1); }
+  100% { opacity: 0;   transform: scale(2.8) translateY(-140px); }
+}
+
+@keyframes wisp {
+  0%   { opacity: 0; transform: translate(var(--wx,0), var(--wy,0)) scale(0.4); }
+  100% { opacity: 0; transform: translate(var(--ex,0), var(--ey,0)) scale(var(--es,2)); }
+}
+
+@keyframes wispMid {
+  50%  { opacity: var(--peak, 0.35); }
+}
+`;
+
+interface WispConfig {
+  ex: number;
+  ey: number;
+  es: number;
+  peak: number;
+  size: number;
+  delay: number;
+  left: string;
+  top: string;
+  rgb: string;
+}
+
+const WISPS: WispConfig[] = [
+  {
+    ex: -120,
+    ey: -220,
+    es: 3.2,
+    peak: 0.4,
+    size: 56,
+    delay: 0,
+    left: "20%",
+    top: "35%",
+    rgb: "200,215,245",
+  },
+  {
+    ex: 110,
+    ey: -250,
+    es: 3.5,
+    peak: 0.35,
+    size: 50,
+    delay: 0.08,
+    left: "58%",
+    top: "30%",
+    rgb: "190,208,240",
+  },
+  {
+    ex: 15,
+    ey: -290,
+    es: 3.8,
+    peak: 0.3,
+    size: 44,
+    delay: 0.15,
+    left: "40%",
+    top: "25%",
+    rgb: "180,200,235",
+  },
+  {
+    ex: -95,
+    ey: -260,
+    es: 3.0,
+    peak: 0.3,
+    size: 48,
+    delay: 0.1,
+    left: "14%",
+    top: "42%",
+    rgb: "195,210,240",
+  },
+  {
+    ex: 130,
+    ey: -200,
+    es: 3.2,
+    peak: 0.25,
+    size: 42,
+    delay: 0.18,
+    left: "64%",
+    top: "38%",
+    rgb: "210,220,248",
+  },
+  {
+    ex: -40,
+    ey: -310,
+    es: 3.5,
+    peak: 0.22,
+    size: 38,
+    delay: 0.24,
+    left: "34%",
+    top: "48%",
+    rgb: "185,205,240",
+  },
+  {
+    ex: 75,
+    ey: -270,
+    es: 3.0,
+    peak: 0.2,
+    size: 36,
+    delay: 0.3,
+    left: "50%",
+    top: "44%",
+    rgb: "205,215,242",
+  },
+];
 
 interface SpeechBubbleProps {
   activeBubble: ActiveBubble | null;
@@ -10,48 +129,121 @@ interface SpeechBubbleProps {
 }
 
 export function SpeechBubble({ activeBubble, characterProgress }: SpeechBubbleProps) {
-  if (!activeBubble || characterProgress === null) return null;
+  const [visibleBubble, setVisibleBubble] = useState<ActiveBubble | null>(null);
+  const prevKeyRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!activeBubble) return;
+
+    const key = `${activeBubble.characterId}-${activeBubble.endTime}`;
+    if (prevKeyRef.current === key) return;
+
+    prevKeyRef.current = key;
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    setVisibleBubble(null);
+    requestAnimationFrame(() => setVisibleBubble(activeBubble));
+
+    timerRef.current = setTimeout(() => {
+      setVisibleBubble(null);
+      prevKeyRef.current = null;
+    }, DURATION_MS + 50);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [activeBubble]);
+
+  if (!visibleBubble || characterProgress === null) return null;
 
   const anchorPos = getTrackPoint(characterProgress);
+  const dur = `${DURATION_MS}ms`;
+  const dissolveDelay = DURATION_MS * 0.33;
+  const wispDur = DURATION_MS * 0.67;
 
   return (
     <group position={[anchorPos.x, anchorPos.y + BUBBLE_Y_OFFSET, anchorPos.z]}>
       <Html center distanceFactor={12} zIndexRange={[1, 0]} style={{ pointerEvents: "none" }}>
+        <style>{KEYFRAMES}</style>
+
         <div
           style={{
             position: "relative",
-            background: "rgba(255, 255, 255, 0.92)",
-            borderRadius: "10px",
-            padding: "6px 12px",
-            fontSize: "13px",
-            lineHeight: 1.35,
-            fontWeight: 600,
-            color: "#1a1a2e",
-            minWidth: "120px",
-            maxWidth: "220px",
-            textAlign: "center",
-            boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
-            border: "1.5px solid rgba(0,0,0,0.08)",
-            whiteSpace: "normal",
-            wordBreak: "keep-all",
-            overflowWrap: "anywhere",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minWidth: "160px",
+            maxWidth: "300px",
             userSelect: "none",
           }}
         >
-          {activeBubble.text}
+          {/* Ambient glow — drifts upward with text */}
           <div
             style={{
               position: "absolute",
-              bottom: "-6px",
-              left: "50%",
-              transform: "translateX(-50%)",
-              width: 0,
-              height: 0,
-              borderLeft: "6px solid transparent",
-              borderRight: "6px solid transparent",
-              borderTop: "6px solid rgba(255, 255, 255, 0.92)",
+              inset: "-28px",
+              borderRadius: "50%",
+              background:
+                "radial-gradient(ellipse at center, rgba(200,215,245,0.25) 0%, transparent 65%)",
+              animation: `glowLife ${dur} ease-in-out forwards`,
+              pointerEvents: "none",
+              willChange: "opacity, transform",
             }}
           />
+
+          {/* Smoke wisps — drift far upward during dissolve */}
+          {WISPS.map((w) => (
+            <div
+              key={`${w.left}-${w.top}`}
+              style={{
+                position: "absolute",
+                left: w.left,
+                top: w.top,
+                width: `${w.size}px`,
+                height: `${w.size * 0.65}px`,
+                borderRadius: "50%",
+                background: `radial-gradient(ellipse, rgba(${w.rgb},0.5) 0%, transparent 65%)`,
+                pointerEvents: "none",
+                opacity: 0,
+                willChange: "opacity, transform",
+                ["--wx" as string]: "0px",
+                ["--wy" as string]: "0px",
+                ["--ex" as string]: `${w.ex}px`,
+                ["--ey" as string]: `${w.ey}px`,
+                ["--es" as string]: w.es,
+                ["--peak" as string]: w.peak,
+                animation: [
+                  `wisp ${wispDur}ms ease-out ${dissolveDelay + w.delay * 1000}ms forwards`,
+                  `wispMid ${wispDur}ms ease-in-out ${dissolveDelay + w.delay * 1000}ms forwards`,
+                ].join(", "),
+              }}
+            />
+          ))}
+
+          {/* Dialogue text */}
+          <span
+            style={{
+              position: "relative",
+              zIndex: 1,
+              fontSize: "20px",
+              lineHeight: 1.45,
+              fontWeight: 800,
+              color: "#fff",
+              textShadow:
+                "0 1px 3px rgba(0,0,0,0.8), 0 0 8px rgba(0,0,0,0.5), 0 0 20px rgba(160,185,240,0.3)",
+              textAlign: "center",
+              whiteSpace: "normal",
+              wordBreak: "keep-all",
+              overflowWrap: "anywhere",
+              letterSpacing: "0.02em",
+              animation: `textLife ${dur} ease-in-out forwards`,
+              willChange: "opacity, transform, filter",
+            }}
+          >
+            {visibleBubble.text}
+          </span>
         </div>
       </Html>
     </group>


### PR DESCRIPTION
## 요약

- 캐릭터 대사 UI를 기존 흰색 말풍선에서 담배연기가 피어올라 멀리 흩날리는 스타일로 전면 교체

## 변경 사항

- `SpeechBubble.tsx` 전면 재작성
  - 흰 배경 + 꼬리 달린 말풍선 UI 제거
  - 텍스트가 ~1초간 선명하게 표시된 후 위로 280px 떠올라가며 blur와 함께 연기처럼 흩어지는 애니메이션으로 교체
  - 7개의 연기 위스프 파티클이 텍스트 dissolve 시점에 사방으로 퍼져나감 (최대 310px 이동)
  - CSS 키프레임을 최소(4단계)로 유지하여 부드러운 보간 확보, 위스프에서 `filter: blur` 제거로 GPU 부하 최소화
  - 컴포넌트가 자체 타이머로 3초 애니메이션 라이프사이클을 관리하여 스토어의 `activeBubble` 해제 시점과 무관하게 애니메이션이 끝까지 재생됨
- 폰트: 13px/600 → 20px/800, 다중 text-shadow로 박스 없이도 가독성 확보

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (pre-push hook에서 lint + format:check + typecheck + build 전체 통과)
  - [x] `pnpm format`
- 수동 확인: 없음 (로컬 dev 서버에서 레이스 실행 후 대사 표시 확인 권장)
- 실행하지 않은 검증과 이유: 브라우저 E2E 테스트 — 프로젝트에 E2E 설정 없음

## 스크린샷 또는 데모

- 스크린샷/영상 없음. 리뷰어가 `pnpm dev:web` 후 레이스를 시작하면 캐릭터 대사에서 연기 효과 확인 가능

## 문서 반영

- [x] 문서 변경 없음
- 관련 문서: 없음 (UI 비주얼 변경만으로 API/라우트/상태 구조 변경 없음)

## 리스크와 후속 작업

- `Html` 컴포넌트 내부에서 CSS 애니메이션 다수가 동시에 돌아가므로 저사양 기기에서 프레임 드랍 가능성 있음. 필요 시 위스프 개수를 줄이거나 `prefers-reduced-motion` 미디어 쿼리 대응 추가
- 대사 표시 시간(3초 애니메이션)이 스토어의 `DIALOGUE_DISPLAY_TIME_MS`(2초)보다 길어서, 빠르게 연속 대사가 나올 경우 이전 대사와 새 대사가 잠시 겹칠 수 있음

Made with [Cursor](https://cursor.com)