### PR TITLE
fix(web): 결과 화면 완주율 표시 FINISH_LINE 기준으로 정규화

### DIFF
--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { Canvas } from "@react-three/fiber";
 import { useMemo } from "react";
 import { resetRouteGuardSnapshot } from "@/features/mountain-race/app";
+import { FINISH_LINE } from "@/features/mountain-race/constants/balance";
 import { useGameStore } from "@/features/mountain-race/store/useGameStore";
 import type { Character, GameEvent } from "@/features/mountain-race/types";
 import { ResultScene } from "./ResultScene";
@@ -208,7 +209,7 @@ export function ResultScreen() {
                       {character.name}
                     </p>
                     <p className="mt-0.5 text-xs tabular-nums text-white/60">
-                      {(character.progress * 100).toFixed(1)}% 완주
+                      {(Math.min(character.progress / FINISH_LINE, 1) * 100).toFixed(1)}% 완주
                     </p>
                     <div className="mt-2 flex justify-center gap-3 text-[0.6rem] text-white/50">
                       <span>피격 {character.stats.hitCount}</span>
@@ -242,7 +243,7 @@ export function ResultScreen() {
                         {character.name}
                       </span>
                       <span className="text-xs tabular-nums text-white/40">
-                        {(character.progress * 100).toFixed(1)}%
+                        {(Math.min(character.progress / FINISH_LINE, 1) * 100).toFixed(1)}%
                       </span>
                       <span className="text-[0.6rem] text-white/30">
                         피격 {character.stats.hitCount} · 역전 {character.stats.rankChanges}


### PR DESCRIPTION
## Summary
- 결과 화면(ResultScreen)에서 완주율을 `progress * 100`으로 계산하던 것을 `progress / FINISH_LINE * 100`으로 변경
- 결승선(`FINISH_LINE = 0.98`)을 통과한 레이서가 100%가 아닌 ~98%로 표시되던 버그 수정
- HUD 진행 바와 동일한 기준으로 통일

## Test plan
- [ ] 레이스를 끝까지 진행하여 완주한 캐릭터의 결과 화면에서 100.0% 완주로 표시되는지 확인
- [ ] 미완주 캐릭터의 완주율이 0~100% 사이에서 정상적으로 표시되는지 확인
- [ ] HUD 진행 바의 표시와 결과 화면의 완주율이 일관되는지 확인

Made with [Cursor](https://cursor.com)