### PR TITLE
feat(web): implement hiking outfit spec for 3D characters

### DIFF
--- a/apps/web/src/features/mountain-race/components/Character.tsx
+++ b/apps/web/src/features/mountain-race/components/Character.tsx
@@ -1,8 +1,8 @@
 import { useRef, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Html } from "@react-three/drei";
-import type { Group } from "three";
-import { Vector3, TextureLoader, SRGBColorSpace } from "three";
+import type { Group, Mesh } from "three";
+import { Vector3, TextureLoader, SRGBColorSpace, Color } from "three";
 import type { Character as CharacterType } from "@/features/mountain-race/types";
 import { getTrackPointTo, getTrackSurfaceY, getTrackTangentTo } from "./Track";
 
@@ -14,15 +14,24 @@ const CHARACTER_FOOT_CLEARANCE = 0.05;
 interface CharacterProps {
   character: CharacterType;
   isFinished: boolean;
+  index: number;
 }
 
-export function Character({ character, isFinished }: CharacterProps) {
+export function Character({ character, isFinished, index }: CharacterProps) {
   const groupRef = useRef<Group>(null);
+  const bellyRef = useRef<Mesh>(null);
   const phaseRef = useRef(0);
 
   const { color, status, name, progress, faceImage } = character;
   const canAnimate = status !== "stunned" && !isFinished;
   const animSpeed = getAnimationSpeed(status);
+  const showVest = index % 3 === 2;
+
+  const backpackColor = useMemo(() => {
+    const c = new Color(color.jacket);
+    c.multiplyScalar(0.6);
+    return `#${c.getHexString()}`;
+  }, [color.jacket]);
 
   useFrame((_, delta) => {
     const group = groupRef.current;
@@ -43,20 +52,39 @@ export function Character({ character, isFinished }: CharacterProps) {
 
     const targetY = groundY + CHARACTER_FOOT_CLEARANCE;
     group.position.y += (targetY - group.position.y) * 0.2;
+
+    // Belly emissive effect
+    const belly = bellyRef.current;
+    if (belly) {
+      const mat = belly.material as import("three").MeshStandardMaterial;
+      if (status === "stunned") {
+        const blink = (Math.sin(phaseRef.current * 4) + 1) * 0.5;
+        mat.emissive.set("#FF0000");
+        mat.emissiveIntensity = blink * 0.8;
+      } else if (status === "boosted") {
+        mat.emissive.set("#FF6600");
+        mat.emissiveIntensity = 0.5;
+      } else {
+        mat.emissive.set("#000000");
+        mat.emissiveIntensity = 0;
+      }
+    }
   });
 
-  const emissive = statusEmissive(status);
   const tiltZ = status === "stunned" ? 0.4 : status === "sliding" ? 0.25 : 0;
 
   return (
     <group ref={groupRef} rotation={[0, 0, tiltZ]}>
       <NameLabel name={name} />
-      <Hat color={color.buff} />
-      <Head emissive={emissive} faceImage={faceImage} />
+      <Hat color={color.hat} />
+      <Head faceImage={faceImage} />
       <Buff color={color.buff} />
-      <Torso color={color.jacket} emissive={emissive} />
-      <Belly color={color.inner} />
-      <Backpack color={color.jacket} />
+      <Torso color={color.jacket} />
+      <Zipper />
+      <Belly ref={bellyRef} color={color.jacket} />
+      {showVest && <Vest color={color.inner} />}
+      <Backpack color={backpackColor} />
+      <BackpackStraps />
       <ArmPair color={color.jacket} canAnimate={canAnimate} animSpeed={animSpeed} />
       <LegPair color={color.pants} canAnimate={canAnimate} animSpeed={animSpeed} />
       <TrekkingPoles canAnimate={canAnimate} animSpeed={animSpeed} />
@@ -79,41 +107,23 @@ function getAnimationSpeed(status: CharacterType["status"]): number {
   }
 }
 
-function statusEmissive(status: CharacterType["status"]): {
-  color: string;
-  intensity: number;
-} {
-  switch (status) {
-    case "boosted":
-      return { color: "#ffff00", intensity: 0.4 };
-    case "stunned":
-      return { color: "#ff0000", intensity: 0.4 };
-    case "slowed":
-      return { color: "#4444ff", intensity: 0.4 };
-    case "sliding":
-      return { color: "#00ccff", intensity: 0.4 };
-    default:
-      return { color: "#000000", intensity: 0 };
-  }
-}
-
 function NameLabel({ name }: { name: string }) {
   return (
-    <Html
-      position={[0, 2.4, 0]}
-      center
-      distanceFactor={15}
-      style={{
-        color: "white",
-        fontSize: "12px",
-        fontWeight: 700,
-        textShadow: "0 1px 3px rgba(0,0,0,0.8)",
-        whiteSpace: "nowrap",
-        pointerEvents: "none",
-        userSelect: "none",
-      }}
-    >
-      {name}
+    <Html position={[0, 2.4, 0]} center distanceFactor={15} style={{ pointerEvents: "none" }}>
+      <div
+        style={{
+          background: "rgba(0,0,0,0.6)",
+          color: "#FFFFFF",
+          fontSize: "12px",
+          fontWeight: 700,
+          padding: "2px 8px",
+          borderRadius: "4px",
+          whiteSpace: "nowrap",
+          userSelect: "none",
+        }}
+      >
+        {name}
+      </div>
     </Html>
   );
 }
@@ -121,25 +131,26 @@ function NameLabel({ name }: { name: string }) {
 function Hat({ color }: { color: string }) {
   return (
     <group position={[0, 1.85, 0]}>
+      {/* dome (hemisphere) */}
       <mesh>
-        <cylinderGeometry args={[0.05, 0.25, 0.18, 8]} />
+        <sphereGeometry args={[0.22, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
         <meshStandardMaterial color={color} />
       </mesh>
-      <mesh position={[0, -0.08, 0]}>
+      {/* brim */}
+      <mesh position={[0, -0.02, 0]}>
         <cylinderGeometry args={[0.3, 0.3, 0.04, 12]} />
+        <meshStandardMaterial color={color} />
+      </mesh>
+      {/* visor */}
+      <mesh position={[0, -0.02, 0.18]}>
+        <boxGeometry args={[0.22, 0.03, 0.14]} />
         <meshStandardMaterial color={color} />
       </mesh>
     </group>
   );
 }
 
-function Head({
-  emissive,
-  faceImage,
-}: {
-  emissive: { color: string; intensity: number };
-  faceImage: string | null;
-}) {
+function Head({ faceImage }: { faceImage: string | null }) {
   const texture = useMemo(() => {
     if (!faceImage?.startsWith("data:image/")) return null;
     const tex = new TextureLoader().load(faceImage);
@@ -151,11 +162,7 @@ function Head({
     <group position={[0, 1.55, 0]}>
       <mesh>
         <sphereGeometry args={[0.25, 12, 10]} />
-        <meshStandardMaterial
-          color="#ffe0bd"
-          emissive={emissive.color}
-          emissiveIntensity={emissive.intensity}
-        />
+        <meshStandardMaterial color="#FFDBAC" roughness={0.6} />
       </mesh>
       {texture ? (
         <group position={[0, 0.02, 0.26]}>
@@ -182,29 +189,39 @@ function Buff({ color }: { color: string }) {
   );
 }
 
-function Torso({
-  color,
-  emissive,
-}: {
-  color: string;
-  emissive: { color: string; intensity: number };
-}) {
+function Torso({ color }: { color: string }) {
   return (
     <mesh position={[0, 0.95, 0]}>
-      <boxGeometry args={[0.5, 0.55, 0.3]} />
-      <meshStandardMaterial
-        color={color}
-        emissive={emissive.color}
-        emissiveIntensity={emissive.intensity}
-      />
+      <capsuleGeometry args={[0.2, 0.35, 6, 12]} />
+      <meshStandardMaterial color={color} />
     </mesh>
   );
 }
 
-function Belly({ color }: { color: string }) {
+function Zipper() {
   return (
-    <mesh position={[0, 0.75, 0.12]}>
+    <mesh position={[0, 0.95, 0.17]}>
+      <boxGeometry args={[0.03, 0.4, 0.02]} />
+      <meshStandardMaterial color="#888888" metalness={0.6} roughness={0.4} />
+    </mesh>
+  );
+}
+
+import { forwardRef } from "react";
+
+const Belly = forwardRef<Mesh, { color: string }>(function Belly({ color }, ref) {
+  return (
+    <mesh ref={ref} position={[0, 0.75, 0.12]}>
       <sphereGeometry args={[0.18, 8, 6]} />
+      <meshStandardMaterial color={color} />
+    </mesh>
+  );
+});
+
+function Vest({ color }: { color: string }) {
+  return (
+    <mesh position={[0, 0.95, 0.02]}>
+      <boxGeometry args={[0.46, 0.45, 0.28]} />
       <meshStandardMaterial color={color} />
     </mesh>
   );
@@ -216,6 +233,21 @@ function Backpack({ color }: { color: string }) {
       <boxGeometry args={[0.3, 0.35, 0.15]} />
       <meshStandardMaterial color={color} roughness={0.8} />
     </mesh>
+  );
+}
+
+function BackpackStraps() {
+  return (
+    <group>
+      <mesh position={[-0.1, 0.98, -0.12]} rotation={[0.15, 0, 0]}>
+        <boxGeometry args={[0.04, 0.35, 0.02]} />
+        <meshStandardMaterial color="#222222" />
+      </mesh>
+      <mesh position={[0.1, 0.98, -0.12]} rotation={[0.15, 0, 0]}>
+        <boxGeometry args={[0.04, 0.35, 0.02]} />
+        <meshStandardMaterial color="#222222" />
+      </mesh>
+    </group>
   );
 }
 
@@ -244,22 +276,22 @@ function LegPair({
     <>
       <group ref={leftRef} position={[-0.13, 0.36, 0.02]}>
         <mesh position={[0, 0.12, 0]}>
-          <boxGeometry args={[0.16, 0.34, 0.16]} />
+          <capsuleGeometry args={[0.07, 0.2, 4, 8]} />
           <meshStandardMaterial color={color} />
         </mesh>
         <mesh position={[0, -0.08, 0.05]}>
           <boxGeometry args={[0.17, 0.12, 0.24]} />
-          <meshStandardMaterial color="#5C4033" />
+          <meshStandardMaterial color="#553311" roughness={0.9} />
         </mesh>
       </group>
       <group ref={rightRef} position={[0.13, 0.36, 0.02]}>
         <mesh position={[0, 0.12, 0]}>
-          <boxGeometry args={[0.16, 0.34, 0.16]} />
+          <capsuleGeometry args={[0.07, 0.2, 4, 8]} />
           <meshStandardMaterial color={color} />
         </mesh>
         <mesh position={[0, -0.08, 0.05]}>
           <boxGeometry args={[0.17, 0.12, 0.24]} />
-          <meshStandardMaterial color="#5C4033" />
+          <meshStandardMaterial color="#553311" roughness={0.9} />
         </mesh>
       </group>
     </>
@@ -291,13 +323,13 @@ function ArmPair({
     <>
       <group ref={leftRef} position={[-0.34, 0.95, 0]}>
         <mesh>
-          <cylinderGeometry args={[0.06, 0.05, 0.45, 6]} />
+          <capsuleGeometry args={[0.05, 0.35, 4, 6]} />
           <meshStandardMaterial color={color} />
         </mesh>
       </group>
       <group ref={rightRef} position={[0.34, 0.95, 0]}>
         <mesh>
-          <cylinderGeometry args={[0.06, 0.05, 0.45, 6]} />
+          <capsuleGeometry args={[0.05, 0.35, 4, 6]} />
           <meshStandardMaterial color={color} />
         </mesh>
       </group>
@@ -321,15 +353,25 @@ function TrekkingPoles({ canAnimate, animSpeed }: { canAnimate: boolean; animSpe
   return (
     <>
       <group ref={leftRef} position={[-0.38, 0.75, 0.1]}>
+        {/* shaft */}
         <mesh>
           <cylinderGeometry args={[0.015, 0.015, 1.2, 4]} />
-          <meshStandardMaterial color="#888888" metalness={0.6} />
+          <meshStandardMaterial color="#AAAAAA" metalness={0.7} roughness={0.3} />
+        </mesh>
+        {/* grip */}
+        <mesh position={[0, 0.55, 0]}>
+          <cylinderGeometry args={[0.025, 0.02, 0.15, 6]} />
+          <meshStandardMaterial color="#333333" roughness={0.9} />
         </mesh>
       </group>
       <group ref={rightRef} position={[0.38, 0.75, 0.1]}>
         <mesh>
           <cylinderGeometry args={[0.015, 0.015, 1.2, 4]} />
-          <meshStandardMaterial color="#888888" metalness={0.6} />
+          <meshStandardMaterial color="#AAAAAA" metalness={0.7} roughness={0.3} />
+        </mesh>
+        <mesh position={[0, 0.55, 0]}>
+          <cylinderGeometry args={[0.025, 0.02, 0.15, 6]} />
+          <meshStandardMaterial color="#333333" roughness={0.9} />
         </mesh>
       </group>
     </>

--- a/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/RaceScreen.tsx
@@ -71,8 +71,13 @@ function SceneContent() {
     <>
       <Track />
       <Environment activeGlobalEvent={activeGlobalEvent} leaderProgress={leaderProgress} />
-      {characters.map((char) => (
-        <Character key={char.id} character={char} isFinished={finishedIds.includes(char.id)} />
+      {characters.map((char, i) => (
+        <Character
+          key={char.id}
+          character={char}
+          isFinished={finishedIds.includes(char.id)}
+          index={i}
+        />
       ))}
       <SpeechBubble activeBubble={activeBubble} characterProgress={bubbleCharProgress} />
       <CameraSystem

--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -27,17 +27,17 @@ import type {
   GlobalEventType,
 } from "../types";
 
-// ── Color presets (8 colors from Product PRD) ──────────────────────────────
+// ── Color presets (8 hiking outfits) ────────────────────────────────────────
 
 const COLOR_PRESETS: readonly ColorPreset[] = [
-  { jacket: "#FF69B4", inner: "#FFFFFF", pants: "#000000", buff: "#C71585" },
-  { jacket: "#4169E1", inner: "#000000", pants: "#333333", buff: "#00008B" },
-  { jacket: "#2E8B57", inner: "#FFFFFF", pants: "#444444", buff: "#006400" },
-  { jacket: "#9370DB", inner: "#CCCCCC", pants: "#000000", buff: "#4B0082" },
-  { jacket: "#FF8C00", inner: "#FFFFFF", pants: "#333333", buff: "#D2691E" },
-  { jacket: "#DC143C", inner: "#000000", pants: "#444444", buff: "#8B0000" },
-  { jacket: "#FFD700", inner: "#000000", pants: "#333333", buff: "#B8860B" },
-  { jacket: "#00CED1", inner: "#FFFFFF", pants: "#000000", buff: "#008B8B" },
+  { jacket: "#FF69B4", inner: "#FFFFFF", pants: "#333333", buff: "#CC3355", hat: "#FF69B4" },
+  { jacket: "#4488CC", inner: "#222222", pants: "#444444", buff: "#3366AA", hat: "#4488CC" },
+  { jacket: "#55BB55", inner: "#EEEEEE", pants: "#555555", buff: "#44AA44", hat: "#55BB55" },
+  { jacket: "#8855CC", inner: "#DDDDDD", pants: "#333333", buff: "#7744BB", hat: "#8855CC" },
+  { jacket: "#FF6633", inner: "#FFFFFF", pants: "#444444", buff: "#EE5522", hat: "#FF6633" },
+  { jacket: "#CC2222", inner: "#222222", pants: "#555555", buff: "#BB1111", hat: "#CC2222" },
+  { jacket: "#F0C030", inner: "#333333", pants: "#444444", buff: "#E0B020", hat: "#F0C030" },
+  { jacket: "#22BBBB", inner: "#FFFFFF", pants: "#333333", buff: "#11AAAA", hat: "#22BBBB" },
 ];
 
 const DEFAULT_NAMES = [
@@ -54,9 +54,25 @@ const DEFAULT_NAMES = [
 const DEFAULT_COLOR: ColorPreset = {
   jacket: "#FF69B4",
   inner: "#FFFFFF",
-  pants: "#000000",
-  buff: "#C71585",
+  pants: "#333333",
+  buff: "#CC3355",
+  hat: "#FF69B4",
 };
+
+/**
+ * 2D UI palette — used for setup screen, ranking bar, progress markers.
+ * Separate from 3D outfit colors for better screen readability.
+ */
+export const UI_PLAYER_COLORS = [
+  "#ff6b35",
+  "#4ecdc4",
+  "#ff69b4",
+  "#7c5cfc",
+  "#2ecc71",
+  "#e74c3c",
+  "#f39c12",
+  "#1abc9c",
+] as const;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/features/mountain-race/types/index.ts
+++ b/apps/web/src/features/mountain-race/types/index.ts
@@ -9,6 +9,7 @@ export interface ColorPreset {
   inner: string;
   pants: string;
   buff: string;
+  hat: string;
 }
 
 // ── Character ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 등산복 캐릭터 8종 컬러 프리셋을 명세서 기준 정확한 HEX 코드로 교체하고, `ColorPreset` 타입에 `hat` 필드를 추가
- Character 3D 메시를 전면 리팩터: Torso/Arm/Leg → CapsuleGeometry, Hat → 돔+챙+바이저 3파츠 구조, Zipper/Vest/BackpackStraps/폴 손잡이 등 신규 파츠 추가
- 상태 이펙트를 Belly 메시에 집중 (스턴=#FF0000 sine 깜빡임, 부스트=#FF6600), 닉네임 라벨에 반투명 배경 박스 적용
- 2D UI용 별도 `UI_PLAYER_COLORS` 팔레트 상수 추가

## Test plan

- [ ] `/race` 화면에서 캐릭터 8종 아웃핏 색상이 명세와 일치하는지 확인
- [ ] 3번째 캐릭터(index 2, 5)에 조끼(Vest)가 표시되는지 확인
- [ ] 모자가 돔+챙+바이저 3파츠로 렌더링되는지 확인
- [ ] 배낭 색상이 자켓보다 어둡고, 배낭 끈이 별도 표시되는지 확인
- [ ] 등산화 색상 #553311, 트레킹 폴 #AAAAAA + 손잡이 #333333 확인
- [ ] 스턴 상태에서 배 부위가 빨간색 sine 깜빡임, 부스트에서 주황색 발광 확인
- [ ] 닉네임이 반투명 검정 배경 라운드 박스 안에 표시되는지 확인
- [ ] `pnpm check` 통과 확인 (lint, format, typecheck, build 모두 통과)


Made with [Cursor](https://cursor.com)