### PR TITLE
feat(web): 순위 변동 추적으로 대역전상 MVP 활성화

### DIFF
--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -65,6 +65,8 @@ function getColorPreset(index: number): ColorPreset {
 }
 
 let idCounter = 0;
+let lastRankChangeCheckTime = 0;
+const RANK_CHANGE_CHECK_INTERVAL = 0.5;
 function nextId(): string {
   idCounter += 1;
   return `char_${idCounter}`;
@@ -201,6 +203,7 @@ export const useGameStore = create<GameState>((set, get) => ({
     }));
     initEventScheduler(0);
     initDialogueScheduler(0);
+    lastRankChangeCheckTime = 0;
     set({
       isRacing: true,
       countdown: 0,
@@ -230,6 +233,7 @@ export const useGameStore = create<GameState>((set, get) => ({
 
   resetGame: () => {
     idCounter = 0;
+    lastRankChangeCheckTime = 0;
     resetEventScheduler();
     resetDialogueScheduler();
     set(getInitialState());
@@ -289,9 +293,23 @@ export const useGameStore = create<GameState>((set, get) => ({
     // 3. Ranking
     const rankings = computeRankings(withFinishTimes);
 
+    // 3.5 Track rank changes (throttled to avoid per-frame jitter noise)
+    let trackedCharacters = withFinishTimes;
+    if (elapsedTime - lastRankChangeCheckTime >= RANK_CHANGE_CHECK_INTERVAL) {
+      lastRankChangeCheckTime = elapsedTime;
+      const prevRankings = state.rankings;
+      trackedCharacters = withFinishTimes.map((c) => {
+        if (finishedIds.includes(c.id)) return c;
+        const prevRank = prevRankings.indexOf(c.id);
+        const currRank = rankings.indexOf(c.id);
+        if (prevRank === -1 || currRank === -1 || prevRank === currRank) return c;
+        return { ...c, stats: { ...c.stats, rankChanges: c.stats.rankChanges + 1 } };
+      });
+    }
+
     // 4. Event system — finished characters are protected from setback/stun
     const eventResult = processEvents({
-      characters: withFinishTimes,
+      characters: trackedCharacters,
       rankings,
       finishedIds,
       elapsedTime,


### PR DESCRIPTION
## Summary
- `tick()` 내에서 이전/현재 rankings를 비교하여 `stats.rankChanges`를 증가시키는 로직 추가
- 0.5초 간격으로 throttle하여 프레임 단위 jitter 노이즈 방지
- 결과 화면의 "대역전상" MVP 카드가 실제 데이터로 동작하게 됨

## Changes
- `apps/web/src/features/mountain-race/store/useGameStore.ts`
  - 모듈 레벨 `lastRankChangeCheckTime` 변수 추가
  - `tick()` 3.5단계에 rank change 감지 + `stats.rankChanges` 증가 로직
  - `startRace()`, `resetGame()`에서 타이머 초기화

## Test plan
- [ ] 레이스 완료 후 결과 화면에서 "대역전상" MVP 카드 표시 확인
- [ ] 역전이 많은 캐릭터가 높은 rankChanges 수치를 갖는지 확인
- [ ] 결과 화면 podium/순위표에 "역전 N" 수치가 0이 아닌 값으로 표시되는지 확인

Made with [Cursor](https://cursor.com)