### PR TITLE
fix(web): 카운트다운 오버레이 숨김 시 레이스 루프 중단 수정

### DIFF
--- a/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
+++ b/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
@@ -75,6 +75,7 @@ function CountdownOverlay({ phase }: { phase: number }) {
 export function RaceRouteComposition() {
   const startRace = useGameStore((s) => s.startRace);
   const tick = useGameStore((s) => s.tick);
+  const isRacing = useGameStore((s) => s.isRacing);
   const [countdownPhase, setCountdownPhase] = useState(COUNTDOWN_SECONDS);
   const raceStarted = useRef(false);
 
@@ -99,12 +100,16 @@ export function RaceRouteComposition() {
     return () => timers.forEach(clearTimeout);
   }, []);
 
-  // Start race loop when countdown reaches 0
+  // Trigger race start when countdown reaches 0
   useEffect(() => {
     if (countdownPhase > 0 || raceStarted.current) return;
     raceStarted.current = true;
-
     startRace();
+  }, [countdownPhase, startRace]);
+
+  // RAF game loop — independent of countdownPhase so the "출발!" hide doesn't kill it
+  useEffect(() => {
+    if (!isRacing) return;
 
     let rafId = 0;
     let prevTime = performance.now();
@@ -122,7 +127,7 @@ export function RaceRouteComposition() {
 
     rafId = window.requestAnimationFrame(loop);
     return () => window.cancelAnimationFrame(rafId);
-  }, [countdownPhase, startRace, tick]);
+  }, [isRacing, tick]);
 
   // Auto-hide "출발!" after a short display
   useEffect(() => {


### PR DESCRIPTION
## 요약

- 카운트다운 "출발!" 텍스트가 사라질 때 RAF 게임 루프가 함께 죽어 레이스가 출발 직후 멈추는 버그 수정

## 변경 사항

- `RaceRouteComposition.tsx`: 하나의 useEffect에 묶여 있던 레이스 시작 트리거와 RAF 게임 루프를 두 개의 독립된 effect로 분리
  - **레이스 시작 트리거**: `countdownPhase`가 0이 되면 `startRace()` 호출
  - **RAF 게임 루프**: `isRacing` 상태에만 의존하여 `countdownPhase` 변경에 영향받지 않음

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (lint + format:check + typecheck + build 모두 통과)
  - [x] 기타: 없음
- 수동 확인: 없음 (브라우저 레이스 플레이 테스트 필요)
- 실행하지 않은 검증과 이유: 브라우저 수동 테스트 — PR 머지 전 preview deploy에서 확인 권장

## 스크린샷 또는 데모

- 시각적 변경 없음 (로직 버그 수정만 해당)

## 문서 반영

- [x] 문서 변경 없음
- 관련 문서: 없음

## 리스크와 후속 작업

- `isRacing` 상태 변경 시점에 RAF 루프가 정확히 시작/종료되므로, `startRace()` 내부에서 `isRacing: true`를 설정하는 현재 구조에 의존함
- 카운트다운 중 다른 화면으로 이탈 후 복귀 시 동작은 별도 확인 필요

Made with [Cursor](https://cursor.com)