### PR TITLE
Phase 2: RaceRoom Durable Object + Hono RPC + WebSocket

### DIFF
--- a/apps/api/src/RaceRoom.ts
+++ b/apps/api/src/RaceRoom.ts
@@ -1,0 +1,279 @@
+import { DurableObject } from "cloudflare:workers";
+import type {
+  ClientMessage,
+  ColorPreset,
+  Player,
+  RoomPhase,
+  RoomState,
+  ServerMessage,
+} from "@mountain-race/types";
+
+interface SessionAttachment {
+  playerId: string;
+}
+
+const COLOR_PRESETS: readonly ColorPreset[] = [
+  { jacket: "#FF69B4", inner: "#FFFFFF", pants: "#333333", buff: "#CC3355", hat: "#FF69B4" },
+  { jacket: "#4488CC", inner: "#222222", pants: "#444444", buff: "#3366AA", hat: "#4488CC" },
+  { jacket: "#55BB55", inner: "#EEEEEE", pants: "#555555", buff: "#44AA44", hat: "#55BB55" },
+  { jacket: "#8855CC", inner: "#DDDDDD", pants: "#333333", buff: "#7744BB", hat: "#8855CC" },
+  { jacket: "#FF6633", inner: "#FFFFFF", pants: "#444444", buff: "#EE5522", hat: "#FF6633" },
+  { jacket: "#CC2222", inner: "#222222", pants: "#555555", buff: "#BB1111", hat: "#CC2222" },
+  { jacket: "#F0C030", inner: "#333333", pants: "#444444", buff: "#E0B020", hat: "#F0C030" },
+  { jacket: "#22BBBB", inner: "#FFFFFF", pants: "#333333", buff: "#11AAAA", hat: "#22BBBB" },
+];
+
+const MAX_PLAYERS = 8;
+const ROOM_TTL_MS = 5 * 60 * 1000;
+
+export class RaceRoom extends DurableObject {
+  private players: Map<string, Player> = new Map();
+  private phase: RoomPhase = "waiting";
+  private hostId: string | null = null;
+  private roomCode: string | null = null;
+
+  constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
+    super(ctx, env);
+    this.restoreSessions();
+    this.ctx.setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"));
+  }
+
+  private restoreSessions(): void {
+    for (const ws of this.ctx.getWebSockets()) {
+      const attachment = ws.deserializeAttachment() as SessionAttachment | null;
+      if (attachment) {
+        const existing = this.players.get(attachment.playerId);
+        if (existing) {
+          existing.connected = true;
+        }
+      }
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.endsWith("/ws")) {
+      return this.handleWebSocket(request);
+    }
+
+    if (request.method === "GET") {
+      return Response.json(this.getRoomState());
+    }
+
+    if (request.method === "POST") {
+      const body = (await request.json()) as { roomCode: string };
+      this.roomCode = body.roomCode;
+      return Response.json({ ok: true, roomCode: this.roomCode });
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  private handleWebSocket(_request: Request): Response {
+    if (this.players.size >= MAX_PLAYERS) {
+      return Response.json({ error: "Room is full" }, { status: 403 });
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+
+    const playerId = crypto.randomUUID();
+    const colorIndex = this.players.size;
+    const color: ColorPreset = COLOR_PRESETS[colorIndex % COLOR_PRESETS.length] ?? {
+      jacket: "#FF69B4",
+      inner: "#FFFFFF",
+      pants: "#333333",
+      buff: "#CC3355",
+      hat: "#FF69B4",
+    };
+
+    const player: Player = {
+      id: playerId,
+      name: `산악인 ${this.players.size + 1}`,
+      color,
+      faceImage: null,
+      ready: false,
+      isHost: this.players.size === 0,
+      connected: true,
+    };
+
+    if (player.isHost) {
+      this.hostId = playerId;
+    }
+
+    this.players.set(playerId, player);
+
+    this.ctx.acceptWebSocket(server);
+    server.serializeAttachment({ playerId } satisfies SessionAttachment);
+
+    this.broadcast({ type: "playerJoined", player });
+    this.sendTo(server, { type: "roomState", state: this.getRoomState() });
+
+    this.resetTTL();
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async webSocketMessage(ws: WebSocket, raw: ArrayBuffer | string): Promise<void> {
+    const attachment = ws.deserializeAttachment() as SessionAttachment | null;
+    if (!attachment) return;
+
+    const player = this.players.get(attachment.playerId);
+    if (!player) return;
+
+    let msg: ClientMessage;
+    try {
+      msg = JSON.parse(typeof raw === "string" ? raw : new TextDecoder().decode(raw));
+    } catch {
+      return;
+    }
+
+    switch (msg.type) {
+      case "setCharacter":
+        player.name = msg.name;
+        player.faceImage = msg.faceImage;
+        player.color = msg.color;
+        this.broadcast({
+          type: "playerUpdated",
+          playerId: player.id,
+          changes: { name: player.name, faceImage: player.faceImage, color: player.color },
+        });
+        break;
+
+      case "setReady":
+        player.ready = msg.ready;
+        this.broadcast({
+          type: "playerUpdated",
+          playerId: player.id,
+          changes: { ready: player.ready },
+        });
+        break;
+
+      case "startRace":
+        if (player.id !== this.hostId) break;
+        if (this.players.size < 2) break;
+        if (!this.allReady()) break;
+        this.startCountdown();
+        break;
+
+      case "activateEffect":
+        // Phase 4에서 구현 예정
+        break;
+    }
+  }
+
+  async webSocketClose(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    _wasClean: boolean,
+  ): Promise<void> {
+    ws.close(code, reason);
+    const attachment = ws.deserializeAttachment() as SessionAttachment | null;
+    if (!attachment) return;
+
+    const player = this.players.get(attachment.playerId);
+    if (!player) return;
+
+    player.connected = false;
+    this.broadcast({ type: "playerLeft", playerId: player.id });
+
+    if (player.isHost) {
+      this.transferHost();
+    }
+
+    if (this.connectedCount() === 0 && this.phase === "waiting") {
+      this.players.clear();
+    }
+
+    this.resetTTL();
+  }
+
+  async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+    const attachment = ws.deserializeAttachment() as SessionAttachment | null;
+    if (attachment) {
+      const player = this.players.get(attachment.playerId);
+      if (player) player.connected = false;
+    }
+    ws.close(1011, "WebSocket error");
+  }
+
+  override async alarm(): Promise<void> {
+    if (this.phase === "waiting" && this.connectedCount() === 0) {
+      this.players.clear();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private getRoomState(): RoomState {
+    return {
+      code: this.roomCode ?? "",
+      phase: this.phase,
+      hostId: this.hostId ?? "",
+      players: [...this.players.values()],
+    };
+  }
+
+  private allReady(): boolean {
+    for (const p of this.players.values()) {
+      if (p.connected && !p.ready) return false;
+    }
+    return true;
+  }
+
+  private connectedCount(): number {
+    let count = 0;
+    for (const p of this.players.values()) {
+      if (p.connected) count++;
+    }
+    return count;
+  }
+
+  private transferHost(): void {
+    for (const p of this.players.values()) {
+      if (p.connected) {
+        p.isHost = true;
+        this.hostId = p.id;
+        this.broadcast({
+          type: "playerUpdated",
+          playerId: p.id,
+          changes: { isHost: true },
+        });
+        return;
+      }
+    }
+    this.hostId = null;
+  }
+
+  private startCountdown(): void {
+    this.phase = "countdown";
+    this.broadcast({ type: "countdown", seconds: 3 });
+    // Phase 3에서 alarm()을 이용한 실제 카운트다운 + 시뮬레이션 구현 예정
+  }
+
+  private broadcast(msg: ServerMessage): void {
+    const data = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(data);
+      } catch {
+        // disconnected, will be cleaned up in webSocketClose
+      }
+    }
+  }
+
+  private sendTo(ws: WebSocket, msg: ServerMessage): void {
+    try {
+      ws.send(JSON.stringify(msg));
+    } catch {
+      // disconnected
+    }
+  }
+
+  private resetTTL(): void {
+    this.ctx.storage.setAlarm(Date.now() + ROOM_TTL_MS);
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,19 +1,29 @@
 import { Hono } from "hono";
+import { roomRoutes } from "./routes/room";
 
-const app = new Hono();
+export { RaceRoom } from "./RaceRoom";
+
+type Env = {
+  Bindings: {
+    RACE_ROOM: DurableObjectNamespace;
+  };
+};
+
+const app = new Hono<Env>();
 
 app.get("/", (c) => {
   return c.json({
     name: "mountain-race-api",
     runtime: "cloudflare-workers",
-    status: "starter",
+    status: "multiplayer",
   });
 });
 
 app.get("/health", (c) => {
-  return c.json({
-    status: "ok",
-  });
+  return c.json({ status: "ok" });
 });
 
+const routes = app.route("/rooms", roomRoutes);
+
 export default app;
+export type AppType = typeof routes;

--- a/apps/api/src/routes/room.ts
+++ b/apps/api/src/routes/room.ts
@@ -1,0 +1,64 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+type Env = {
+  Bindings: {
+    RACE_ROOM: DurableObjectNamespace;
+  };
+};
+
+function generateRoomCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+  let code = "";
+  for (let i = 0; i < 4; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
+export const roomRoutes = new Hono<Env>()
+  .use("*", cors())
+  .post("/", async (c) => {
+    const code = generateRoomCode();
+    const id = c.env.RACE_ROOM.idFromName(code);
+    const stub = c.env.RACE_ROOM.get(id);
+
+    const res = await stub.fetch(
+      new Request("https://do/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ roomCode: code }),
+      }),
+    );
+
+    if (!res.ok) {
+      return c.json({ error: "Failed to create room" }, 500);
+    }
+
+    return c.json({ roomCode: code }, 201);
+  })
+  .get("/:code", async (c) => {
+    const code = c.req.param("code").toUpperCase();
+    const id = c.env.RACE_ROOM.idFromName(code);
+    const stub = c.env.RACE_ROOM.get(id);
+
+    const res = await stub.fetch(new Request("https://do/state"));
+    const state = await res.json();
+    return c.json(state, 200);
+  })
+  .get("/:code/ws", async (c) => {
+    const upgradeHeader = c.req.header("Upgrade");
+    if (!upgradeHeader || upgradeHeader !== "websocket") {
+      return c.text("Expected Upgrade: websocket", 426);
+    }
+
+    const code = c.req.param("code").toUpperCase();
+    const id = c.env.RACE_ROOM.idFromName(code);
+    const stub = c.env.RACE_ROOM.get(id);
+
+    return stub.fetch(
+      new Request("https://do/ws", {
+        headers: c.req.raw.headers,
+      }),
+    );
+  });

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -3,4 +3,18 @@
   "name": "mountain-race-api",
   "main": "src/index.ts",
   "compatibility_date": "2026-04-02",
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RACE_ROOM",
+        "class_name": "RaceRoom",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_classes": ["RaceRoom"],
+    },
+  ],
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@react-three/drei": "catalog:",
     "@react-three/fiber": "catalog:",
     "@tanstack/react-router": "catalog:",
+    "hono": "catalog:",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.10
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)


### PR DESCRIPTION
## Summary
- `RaceRoom` Durable Object: WebSocket Hibernation API, 방 생성/참가/이탈/준비/호스트 이전/TTL 정리
- Hono RPC 라우트: `POST /rooms` (생성), `GET /rooms/:code` (상태), `GET /rooms/:code/ws` (WebSocket)
- `AppType` export로 web에서 `hc<AppType>()`으로 타입 세이프 클라이언트 사용 가능
- `wrangler.jsonc`: RACE_ROOM DO 바인딩 + v1 마이그레이션
- `apps/web`: hono 의존성 추가 (향후 RPC 클라이언트용)

## Verification
- [x] `pnpm check` 전체 통과 (lint + format + typecheck + build)
- [x] `wrangler deploy --dry-run` 성공, DO 바인딩 인식됨
- [ ] `wrangler dev`로 WebSocket 연결 에코 테스트 (로컬 수동 확인 필요)

## Next
- Phase 3: 서버 사이드 시뮬레이션 tick + 상태 브로드캐스트


Made with [Cursor](https://cursor.com)