### PR TITLE
Phase 4: Hidden effect system — assignment, activation, reveal

### DIFF
--- a/apps/api/src/domain/effects/badEffects.ts
+++ b/apps/api/src/domain/effects/badEffects.ts
@@ -1,0 +1,50 @@
+import type { EffectContext, EffectHandler, EffectResult } from "./effectHandler";
+
+export const selfTripEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
+    const updated = [...characters];
+    updated[casterIndex] = {
+      ...caster,
+      status: "stunned",
+      speed: 0,
+      stunEndTime: elapsedTime + 1.2,
+      stats: { ...caster.stats, hitCount: caster.stats.hitCount + 1 },
+    };
+    return { characters: updated };
+  },
+};
+
+export const ankleWeightEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
+    const updated = [...characters];
+    updated[casterIndex] = {
+      ...caster,
+      status: "slowed",
+      speed: caster.baseSpeed * 0.7,
+      stunEndTime: elapsedTime + 3,
+    };
+    return { characters: updated };
+  },
+};
+
+export const magnetEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters, rankings }: EffectContext): EffectResult {
+    const updated = [...characters];
+    const rankIndex = rankings.indexOf(caster.id);
+    const secondPlaceId = rankings[1];
+
+    if (rankIndex > 0 && secondPlaceId) {
+      const second = updated.find((c) => c.id === secondPlaceId);
+      if (second) {
+        const pullback = Math.abs(caster.progress - second.progress) * 0.5;
+        updated[casterIndex] = {
+          ...caster,
+          progress: Math.max(0, caster.progress - pullback),
+          stats: { ...caster.stats, setbackTotal: caster.stats.setbackTotal + pullback },
+        };
+      }
+    }
+
+    return { characters: updated };
+  },
+};

--- a/apps/api/src/domain/effects/effectHandler.ts
+++ b/apps/api/src/domain/effects/effectHandler.ts
@@ -1,0 +1,18 @@
+import type { Character } from "@mountain-race/types";
+
+export interface EffectContext {
+  casterIndex: number;
+  caster: Character;
+  characters: Character[];
+  rankings: string[];
+  elapsedTime: number;
+}
+
+export interface EffectResult {
+  characters: Character[];
+  targetName?: string;
+}
+
+export interface EffectHandler {
+  apply(ctx: EffectContext): EffectResult;
+}

--- a/apps/api/src/domain/effects/effectRegistry.ts
+++ b/apps/api/src/domain/effects/effectRegistry.ts
@@ -1,0 +1,20 @@
+import type { HiddenEffectType } from "@mountain-race/types";
+import type { EffectHandler } from "./effectHandler";
+import { boosterEffect, shieldEffect, windRideEffect } from "./goodEffects";
+import { ankleWeightEffect, magnetEffect, selfTripEffect } from "./badEffects";
+import { earthquakeEffect, mysterySwapEffect } from "./wildcardEffects";
+
+const registry: Record<HiddenEffectType, EffectHandler> = {
+  booster: boosterEffect,
+  wind_ride: windRideEffect,
+  shield: shieldEffect,
+  self_trip: selfTripEffect,
+  ankle_weight: ankleWeightEffect,
+  magnet: magnetEffect,
+  mystery_swap: mysterySwapEffect,
+  earthquake: earthquakeEffect,
+};
+
+export function getEffectHandler(type: HiddenEffectType): EffectHandler {
+  return registry[type];
+}

--- a/apps/api/src/domain/effects/goodEffects.ts
+++ b/apps/api/src/domain/effects/goodEffects.ts
@@ -1,0 +1,38 @@
+import type { EffectContext, EffectHandler, EffectResult } from "./effectHandler";
+
+export const boosterEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
+    const updated = [...characters];
+    updated[casterIndex] = {
+      ...caster,
+      status: "boosted",
+      speed: caster.baseSpeed * 2.5,
+      stunEndTime: elapsedTime + 2,
+    };
+    return { characters: updated };
+  },
+};
+
+export const windRideEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
+    const updated = [...characters];
+    updated[casterIndex] = {
+      ...caster,
+      status: "boosted",
+      speed: caster.baseSpeed * 1.8,
+      stunEndTime: elapsedTime + 1.5,
+    };
+    return { characters: updated };
+  },
+};
+
+export const shieldEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters }: EffectContext): EffectResult {
+    const updated = [...characters];
+    updated[casterIndex] = {
+      ...caster,
+      stats: { ...caster.stats, hitCount: caster.stats.hitCount - 1 },
+    };
+    return { characters: updated };
+  },
+};

--- a/apps/api/src/domain/effects/index.ts
+++ b/apps/api/src/domain/effects/index.ts
@@ -1,0 +1,2 @@
+export type { EffectHandler, EffectContext, EffectResult } from "./effectHandler";
+export { getEffectHandler } from "./effectRegistry";

--- a/apps/api/src/domain/effects/wildcardEffects.ts
+++ b/apps/api/src/domain/effects/wildcardEffects.ts
@@ -1,0 +1,48 @@
+import type { EffectContext, EffectHandler, EffectResult } from "./effectHandler";
+
+export const mysterySwapEffect: EffectHandler = {
+  apply({ casterIndex, caster, characters }: EffectContext): EffectResult {
+    const updated = [...characters];
+
+    let closestIdx = -1;
+    let closestDist = Number.POSITIVE_INFINITY;
+
+    for (let i = 0; i < updated.length; i++) {
+      const other = updated[i];
+      if (!other || other.id === caster.id) continue;
+      const dist = Math.abs(other.progress - caster.progress);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+
+    if (closestIdx !== -1) {
+      const target = updated[closestIdx];
+      if (target) {
+        const myProgress = caster.progress;
+        updated[casterIndex] = { ...caster, progress: target.progress };
+        updated[closestIdx] = { ...target, progress: myProgress };
+        return { characters: updated, targetName: target.name };
+      }
+    }
+
+    return { characters: updated };
+  },
+};
+
+export const earthquakeEffect: EffectHandler = {
+  apply({ characters, elapsedTime }: EffectContext): EffectResult {
+    const updated = characters.map((c) => {
+      if (c.finishTime !== null) return c;
+      return {
+        ...c,
+        status: "stunned" as const,
+        speed: 0,
+        stunEndTime: elapsedTime + 0.8,
+        stats: { ...c.stats, hitCount: c.stats.hitCount + 1 },
+      };
+    });
+    return { characters: updated };
+  },
+};

--- a/apps/api/src/domain/hiddenEffectManager.ts
+++ b/apps/api/src/domain/hiddenEffectManager.ts
@@ -1,0 +1,249 @@
+import type {
+  Character,
+  HiddenEffect,
+  HiddenEffectAssignment,
+  HiddenEffectCategory,
+  HiddenEffectType,
+} from "@mountain-race/types";
+import { GAME_SPEED } from "@mountain-race/game-logic";
+
+// ── Effect pool ──────────────────────────────────────────────────────────
+
+const EFFECT_POOL: readonly HiddenEffect[] = [
+  {
+    type: "booster",
+    category: "good",
+    name: "부스터",
+    description: "2초간 속도 2.5배",
+    emoji: "🚀",
+  },
+  {
+    type: "wind_ride",
+    category: "good",
+    name: "바람 타기",
+    description: "1.5초간 속도 1.8배",
+    emoji: "💨",
+  },
+  {
+    type: "shield",
+    category: "good",
+    name: "쉴드",
+    description: "다음 방해 1회 무효화",
+    emoji: "🛡️",
+  },
+  { type: "self_trip", category: "bad", name: "넘어지기", description: "1.2초 스턴", emoji: "😵" },
+  {
+    type: "ankle_weight",
+    category: "bad",
+    name: "발목에 추",
+    description: "3초간 감속",
+    emoji: "⚓",
+  },
+  { type: "magnet", category: "bad", name: "자석", description: "2등에게 끌려감", emoji: "🧲" },
+  {
+    type: "mystery_swap",
+    category: "wildcard",
+    name: "미스터리 스왑",
+    description: "가장 가까운 상대와 위치 교환",
+    emoji: "🔄",
+  },
+  {
+    type: "earthquake",
+    category: "wildcard",
+    name: "지진",
+    description: "전원 0.8초 스턴",
+    emoji: "🌍",
+  },
+];
+
+const CATEGORY_WEIGHTS: Record<HiddenEffectCategory, number> = {
+  good: 0.4,
+  bad: 0.4,
+  wildcard: 0.2,
+};
+
+// ── Manager ──────────────────────────────────────────────────────────────
+
+export class HiddenEffectManager {
+  private assignments: Map<string, HiddenEffectAssignment> = new Map();
+
+  assignEffects(playerIds: string[]): void {
+    this.assignments.clear();
+    for (const playerId of playerIds) {
+      const effect = this.pickRandomEffect();
+      this.assignments.set(playerId, {
+        playerId,
+        effect,
+        activated: false,
+        activatedAt: null,
+      });
+    }
+  }
+
+  canActivate(playerId: string): boolean {
+    const assignment = this.assignments.get(playerId);
+    return assignment !== undefined && !assignment.activated;
+  }
+
+  activate(playerId: string, elapsedTime: number): HiddenEffectAssignment | null {
+    const assignment = this.assignments.get(playerId);
+    if (!assignment || assignment.activated) return null;
+
+    assignment.activated = true;
+    assignment.activatedAt = elapsedTime;
+    return assignment;
+  }
+
+  applyEffect(
+    assignment: HiddenEffectAssignment,
+    characters: Character[],
+    rankings: string[],
+    elapsedTime: number,
+  ): { characters: Character[]; targetName?: string } {
+    const charIndex = characters.findIndex((c) => c.id === assignment.playerId);
+    if (charIndex === -1) return { characters };
+
+    const char = characters[charIndex];
+    if (!char) return { characters };
+    let updated = [...characters];
+
+    switch (assignment.effect.type) {
+      case "booster":
+        updated[charIndex] = {
+          ...char,
+          status: "boosted",
+          speed: char.baseSpeed * 2.5,
+          stunEndTime: elapsedTime + 2,
+        };
+        break;
+
+      case "wind_ride":
+        updated[charIndex] = {
+          ...char,
+          status: "boosted",
+          speed: char.baseSpeed * 1.8,
+          stunEndTime: elapsedTime + 1.5,
+        };
+        break;
+
+      case "shield":
+        // shield 상태를 표현하기 위해 stats에 기록 (hitCount를 -1로 마킹)
+        // 실제 shield 로직은 EventSystem에서 hitCount < 0 일 때 방어 후 0으로 복구
+        updated[charIndex] = {
+          ...char,
+          stats: { ...char.stats, hitCount: char.stats.hitCount - 1 },
+        };
+        break;
+
+      case "self_trip":
+        updated[charIndex] = {
+          ...char,
+          status: "stunned",
+          speed: 0,
+          stunEndTime: elapsedTime + 1.2,
+          stats: { ...char.stats, hitCount: char.stats.hitCount + 1 },
+        };
+        break;
+
+      case "ankle_weight":
+        updated[charIndex] = {
+          ...char,
+          status: "slowed",
+          speed: char.baseSpeed * 0.7,
+          stunEndTime: elapsedTime + 3,
+        };
+        break;
+
+      case "magnet": {
+        const rankIndex = rankings.indexOf(assignment.playerId);
+        const secondPlaceId = rankings[1];
+        if (rankIndex > 0 && secondPlaceId) {
+          const second = updated.find((c) => c.id === secondPlaceId);
+          if (second) {
+            const pullback = Math.abs(char.progress - second.progress) * 0.5;
+            updated[charIndex] = {
+              ...char,
+              progress: Math.max(0, char.progress - pullback),
+              stats: { ...char.stats, setbackTotal: char.stats.setbackTotal + pullback },
+            };
+          }
+        }
+        break;
+      }
+
+      case "mystery_swap": {
+        let closestIdx = -1;
+        let closestDist = Number.POSITIVE_INFINITY;
+        for (let i = 0; i < updated.length; i++) {
+          const other = updated[i];
+          if (!other) continue;
+          if (other.id === char.id) continue;
+          const dist = Math.abs(other.progress - char.progress);
+          if (dist < closestDist) {
+            closestDist = dist;
+            closestIdx = i;
+          }
+        }
+        if (closestIdx !== -1) {
+          const target = updated[closestIdx];
+          if (!target) break;
+          const myProgress = char.progress;
+          updated[charIndex] = { ...char, progress: target.progress };
+          updated[closestIdx] = { ...target, progress: myProgress };
+          return { characters: updated, targetName: target.name };
+        }
+        break;
+      }
+
+      case "earthquake":
+        updated = updated.map((c) => {
+          if (c.finishTime !== null) return c;
+          return {
+            ...c,
+            status: "stunned" as const,
+            speed: 0,
+            stunEndTime: elapsedTime + 0.8,
+            stats: { ...c.stats, hitCount: c.stats.hitCount + 1 },
+          };
+        });
+        break;
+    }
+
+    return { characters: updated };
+  }
+
+  allAssignments(): HiddenEffectAssignment[] {
+    return [...this.assignments.values()];
+  }
+
+  getAssignment(playerId: string): HiddenEffectAssignment | undefined {
+    return this.assignments.get(playerId);
+  }
+
+  private pickRandomEffect(): HiddenEffect {
+    const roll = Math.random();
+    let category: HiddenEffectCategory;
+
+    if (roll < CATEGORY_WEIGHTS.good) {
+      category = "good";
+    } else if (roll < CATEGORY_WEIGHTS.good + CATEGORY_WEIGHTS.bad) {
+      category = "bad";
+    } else {
+      category = "wildcard";
+    }
+
+    const pool = EFFECT_POOL.filter((e) => e.category === category);
+    const idx = Math.floor(Math.random() * pool.length);
+    const fallback = EFFECT_POOL[0];
+    return (
+      pool[idx] ??
+      fallback ?? {
+        type: "booster",
+        category: "good",
+        name: "부스터",
+        description: "2초간 속도 2.5배",
+        emoji: "🚀",
+      }
+    );
+  }
+}

--- a/apps/api/src/domain/hiddenEffectManager.ts
+++ b/apps/api/src/domain/hiddenEffectManager.ts
@@ -5,7 +5,7 @@ import type {
   HiddenEffectCategory,
   HiddenEffectType,
 } from "@mountain-race/types";
-import { GAME_SPEED } from "@mountain-race/game-logic";
+import { getEffectHandler } from "./effects";
 
 // ── Effect pool ──────────────────────────────────────────────────────────
 
@@ -100,116 +100,14 @@ export class HiddenEffectManager {
     rankings: string[],
     elapsedTime: number,
   ): { characters: Character[]; targetName?: string } {
-    const charIndex = characters.findIndex((c) => c.id === assignment.playerId);
-    if (charIndex === -1) return { characters };
+    const casterIndex = characters.findIndex((c) => c.id === assignment.playerId);
+    if (casterIndex === -1) return { characters };
 
-    const char = characters[charIndex];
-    if (!char) return { characters };
-    let updated = [...characters];
+    const caster = characters[casterIndex];
+    if (!caster) return { characters };
 
-    switch (assignment.effect.type) {
-      case "booster":
-        updated[charIndex] = {
-          ...char,
-          status: "boosted",
-          speed: char.baseSpeed * 2.5,
-          stunEndTime: elapsedTime + 2,
-        };
-        break;
-
-      case "wind_ride":
-        updated[charIndex] = {
-          ...char,
-          status: "boosted",
-          speed: char.baseSpeed * 1.8,
-          stunEndTime: elapsedTime + 1.5,
-        };
-        break;
-
-      case "shield":
-        // shield 상태를 표현하기 위해 stats에 기록 (hitCount를 -1로 마킹)
-        // 실제 shield 로직은 EventSystem에서 hitCount < 0 일 때 방어 후 0으로 복구
-        updated[charIndex] = {
-          ...char,
-          stats: { ...char.stats, hitCount: char.stats.hitCount - 1 },
-        };
-        break;
-
-      case "self_trip":
-        updated[charIndex] = {
-          ...char,
-          status: "stunned",
-          speed: 0,
-          stunEndTime: elapsedTime + 1.2,
-          stats: { ...char.stats, hitCount: char.stats.hitCount + 1 },
-        };
-        break;
-
-      case "ankle_weight":
-        updated[charIndex] = {
-          ...char,
-          status: "slowed",
-          speed: char.baseSpeed * 0.7,
-          stunEndTime: elapsedTime + 3,
-        };
-        break;
-
-      case "magnet": {
-        const rankIndex = rankings.indexOf(assignment.playerId);
-        const secondPlaceId = rankings[1];
-        if (rankIndex > 0 && secondPlaceId) {
-          const second = updated.find((c) => c.id === secondPlaceId);
-          if (second) {
-            const pullback = Math.abs(char.progress - second.progress) * 0.5;
-            updated[charIndex] = {
-              ...char,
-              progress: Math.max(0, char.progress - pullback),
-              stats: { ...char.stats, setbackTotal: char.stats.setbackTotal + pullback },
-            };
-          }
-        }
-        break;
-      }
-
-      case "mystery_swap": {
-        let closestIdx = -1;
-        let closestDist = Number.POSITIVE_INFINITY;
-        for (let i = 0; i < updated.length; i++) {
-          const other = updated[i];
-          if (!other) continue;
-          if (other.id === char.id) continue;
-          const dist = Math.abs(other.progress - char.progress);
-          if (dist < closestDist) {
-            closestDist = dist;
-            closestIdx = i;
-          }
-        }
-        if (closestIdx !== -1) {
-          const target = updated[closestIdx];
-          if (!target) break;
-          const myProgress = char.progress;
-          updated[charIndex] = { ...char, progress: target.progress };
-          updated[closestIdx] = { ...target, progress: myProgress };
-          return { characters: updated, targetName: target.name };
-        }
-        break;
-      }
-
-      case "earthquake":
-        updated = updated.map((c) => {
-          if (c.finishTime !== null) return c;
-          return {
-            ...c,
-            status: "stunned" as const,
-            speed: 0,
-            stunEndTime: elapsedTime + 0.8,
-            stats: { ...c.stats, hitCount: c.stats.hitCount + 1 },
-          };
-        });
-        break;
-    }
-
-    return { characters: updated };
+    const handler = getEffectHandler(assignment.effect.type);
+    return handler.apply({ casterIndex, caster, characters, rankings, elapsedTime });
   }
 
   allAssignments(): HiddenEffectAssignment[] {

--- a/apps/api/src/domain/raceSimulation.ts
+++ b/apps/api/src/domain/raceSimulation.ts
@@ -18,6 +18,7 @@ import {
   processDialogues,
   processEvents,
 } from "@mountain-race/game-logic";
+import { HiddenEffectManager } from "./hiddenEffectManager";
 
 const BROADCAST_INTERVAL_S = 0.05;
 
@@ -52,6 +53,7 @@ export class RaceSimulation {
   private activeBubble: ActiveBubble | null = null;
   private lastBroadcastAt = 0;
   private lastTickWallTime = 0;
+  readonly effects = new HiddenEffectManager();
 
   get isFinished(): boolean {
     return this._finished;
@@ -94,6 +96,7 @@ export class RaceSimulation {
 
     initEventScheduler(0);
     initDialogueScheduler(0);
+    this.effects.assignEffects(this.characters.map((c) => c.id));
   }
 
   tick(): void {
@@ -110,6 +113,26 @@ export class RaceSimulation {
     this.runEventSystem();
     this.runDialogueSystem();
     this.checkRaceEnd();
+  }
+
+  activateEffect(playerId: string): {
+    assignment: HiddenEffectAssignment;
+    targetName: string | undefined;
+  } | null {
+    if (!this.effects.canActivate(playerId)) return null;
+
+    const assignment = this.effects.activate(playerId, this.elapsedTime);
+    if (!assignment) return null;
+
+    const result = this.effects.applyEffect(
+      assignment,
+      this.characters,
+      this.rankings,
+      this.elapsedTime,
+    );
+    this.characters = result.characters;
+
+    return { assignment, targetName: result.targetName };
   }
 
   markBroadcasted(): void {
@@ -141,7 +164,7 @@ export class RaceSimulation {
     return {
       rankings: finalRankings,
       characters: this.characters,
-      hiddenEffects: [], // Phase 4에서 채움
+      hiddenEffects: this.effects.allAssignments(),
     };
   }
 

--- a/apps/api/src/infrastructure/durableObject/RaceRoom.ts
+++ b/apps/api/src/infrastructure/durableObject/RaceRoom.ts
@@ -97,7 +97,8 @@ export class RaceRoom extends DurableObject implements Broadcaster {
         break;
 
       case "activateEffect":
-        // Phase 4에서 구현 예정
+        if (this.registry.phase !== "racing") break;
+        this.handleActivateEffect(playerId);
         break;
     }
   }
@@ -156,7 +157,23 @@ export class RaceRoom extends DurableObject implements Broadcaster {
 
     this.registry.phase = "racing";
     this.simulation.init(this.registry.connectedPlayers);
+    this.broadcast({ type: "hasHiddenEffect", hasEffect: true });
     this.ctx.storage.setAlarm(Date.now() + SIM_TICK_MS);
+  }
+
+  // ── Hidden effect activation ─────────────────────────────────────────
+
+  private handleActivateEffect(playerId: string): void {
+    const result = this.simulation.activateEffect(playerId);
+    if (!result) return;
+
+    const reveal: ServerMessage = {
+      type: "effectReveal",
+      playerId,
+      effect: result.assignment.effect,
+      ...(result.targetName !== undefined ? { targetName: result.targetName } : {}),
+    };
+    this.broadcast(reveal);
   }
 
   // ── Race tick ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `domain/hiddenEffectManager.ts`: 효과 풀 8종 (좋은 40%, 나쁜 40%, 와일드카드 20%), 랜덤 배정, 발동 + 적용 로직
  - 좋은: booster, wind_ride, shield
  - 나쁜: self_trip, ankle_weight, magnet
  - 와일드카드: mystery_swap, earthquake
- `RaceSimulation`: HiddenEffectManager 통합 — init 시 배정, activateEffect() 노출, 결과에 전체 배정 정보 포함
- `RaceRoom DO`: activateEffect 메시지 처리, EffectReveal 브로드캐스트, 레이스 시작 시 hasHiddenEffect 전송

## Mechanic
- 플레이어는 자기가 받은 효과를 모름
- 관전 중 "? 발동" 버튼으로 직접 선택하여 발동 (안 쓸 수도 있음)
- 발동 시 모든 클라이언트에 효과 공개 연출
- 결과 화면에서 미사용 효과도 전체 공개

## Verification
- [x] `pnpm check` 전체 통과
- [x] `wrangler deploy --dry-run` 성공 (132KB bundle)

## Next
- Phase 5: LobbyScreen + useConnectionStore + WebSocket 연결


Made with [Cursor](https://cursor.com)