### PR TITLE
Phase 5: Lobby screen + connection store + multiplayer landing

### DIFF
--- a/.github/workflows/deploy-api-staging.yml
+++ b/.github/workflows/deploy-api-staging.yml
@@ -1,0 +1,61 @@
+name: Deploy API To Cloudflare Workers (Staging)
+
+on:
+  push:
+    branches:
+      - "feat/multiplayer-base"
+      - "feat/mp-*"
+    paths:
+      - ".node-version"
+      - ".github/workflows/deploy-api-staging.yml"
+      - "apps/api/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tsconfig.base.json"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-api-staging
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.25.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build API worker
+        run: pnpm build:api
+
+      - name: Deploy staging API worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: apps/api
+          wranglerVersion: 4.80.0
+          command: deploy --name mountain-race-api-staging

--- a/apps/api/src/application/shared/playerRegistry.ts
+++ b/apps/api/src/application/shared/playerRegistry.ts
@@ -91,6 +91,7 @@ export class PlayerRegistry {
 
   allReady(): boolean {
     for (const p of this.players.values()) {
+      if (p.isHost) continue;
       if (p.connected && !p.ready) return false;
     }
     return true;

--- a/apps/api/src/application/shared/playerRegistry.ts
+++ b/apps/api/src/application/shared/playerRegistry.ts
@@ -51,6 +51,13 @@ export class PlayerRegistry {
     return this.players.get(id);
   }
 
+  restorePlayer(player: Player): void {
+    this.players.set(player.id, player);
+    if (player.isHost) {
+      this._hostId = player.id;
+    }
+  }
+
   addPlayer(): Player {
     const playerId = crypto.randomUUID();
     const colorIndex = this.players.size;

--- a/apps/api/src/infrastructure/durableObject/RaceRoom.ts
+++ b/apps/api/src/infrastructure/durableObject/RaceRoom.ts
@@ -10,8 +10,11 @@ import {
   handlePlayerDisconnect,
 } from "../../application/room/useCases";
 
+import type { Player } from "@mountain-race/types";
+
 interface SessionAttachment {
   playerId: string;
+  player: Player;
 }
 
 const ROOM_TTL_MS = 5 * 60 * 1000;
@@ -55,10 +58,14 @@ export class RaceRoom extends DurableObject implements Broadcaster {
     const player = this.registry.addPlayer();
 
     this.ctx.acceptWebSocket(server);
-    server.serializeAttachment({ playerId: player.id } satisfies SessionAttachment);
+    server.serializeAttachment({ playerId: player.id, player } satisfies SessionAttachment);
 
     this.broadcast({ type: "playerJoined", player });
-    this.sendTo(server, { type: "roomState", state: this.registry.roomState() });
+    this.sendTo(server, {
+      type: "roomState",
+      state: this.registry.roomState(),
+      yourPlayerId: player.id,
+    });
     this.scheduleRoomTTL();
 
     return new Response(null, { status: 101, webSocket: client });
@@ -83,10 +90,12 @@ export class RaceRoom extends DurableObject implements Broadcaster {
     switch (msg.type) {
       case "setCharacter":
         handleSetCharacter(deps, player, msg);
+        ws.serializeAttachment({ playerId: player.id, player } satisfies SessionAttachment);
         break;
 
       case "setReady":
         handleSetReady(deps, player, msg);
+        ws.serializeAttachment({ playerId: player.id, player } satisfies SessionAttachment);
         break;
 
       case "startRace":
@@ -254,10 +263,14 @@ export class RaceRoom extends DurableObject implements Broadcaster {
 
   private restoreHibernatedSessions(): void {
     for (const ws of this.ctx.getWebSockets()) {
-      const id = this.playerIdFrom(ws);
-      if (id) {
-        const player = this.registry.get(id);
-        if (player) player.connected = true;
+      const attachment = ws.deserializeAttachment() as SessionAttachment | null;
+      if (!attachment) continue;
+
+      const existing = this.registry.get(attachment.playerId);
+      if (existing) {
+        existing.connected = true;
+      } else if (attachment.player) {
+        this.registry.restorePlayer({ ...attachment.player, connected: true });
       }
     }
   }

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -14,7 +14,7 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_classes": ["RaceRoom"],
+      "new_sqlite_classes": ["RaceRoom"],
     },
   ],
 }

--- a/apps/web/src/features/mountain-race/screens/LandingScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LandingScreen.tsx
@@ -1,15 +1,37 @@
+import { useConnectionStore } from "@/features/mountain-race/store/useConnectionStore";
 import { useGameStore } from "@/features/mountain-race/store/useGameStore";
 import { Canvas } from "@react-three/fiber";
-import { Link } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
 import { LandingScene } from "./LandingScene";
 
 export function LandingScreen() {
   const resetGame = useGameStore((s) => s.resetGame);
+  const createRoom = useConnectionStore((s) => s.createRoom);
+  const joinRoom = useConnectionStore((s) => s.joinRoom);
+  const navigate = useNavigate();
+
+  const [showJoin, setShowJoin] = useState(false);
+  const [joinCode, setJoinCode] = useState("");
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     resetGame();
   }, [resetGame]);
+
+  const handleCreate = useCallback(async () => {
+    setCreating(true);
+    const code = await createRoom();
+    setCreating(false);
+    if (code) void navigate({ to: "/lobby" });
+  }, [createRoom, navigate]);
+
+  const handleJoin = useCallback(() => {
+    const code = joinCode.trim().toUpperCase();
+    if (code.length < 4) return;
+    joinRoom(code);
+    void navigate({ to: "/lobby" });
+  }, [joinCode, joinRoom, navigate]);
 
   return (
     <main
@@ -70,13 +92,57 @@ export function LandingScreen() {
 
         {/* CTA */}
         <div className="mt-8 flex flex-col items-center gap-3 md:mt-10">
+          <div className="flex w-full max-w-xs flex-col gap-3 sm:flex-row sm:max-w-none sm:justify-center">
+            <button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={creating}
+              className="group relative inline-flex h-12 items-center justify-center overflow-hidden rounded-xl bg-white px-8 text-base font-bold text-zinc-900 shadow-lg transition-all duration-200 hover:scale-[1.03] hover:shadow-xl active:scale-[0.98] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:h-14 md:px-10 md:text-lg"
+            >
+              <span className="relative z-10">{creating ? "생성 중…" : "방 만들기"}</span>
+              <span className="absolute inset-0 -z-0 bg-gradient-to-r from-emerald-100 via-white to-sky-100 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setShowJoin((v) => !v)}
+              className="group relative inline-flex h-12 items-center justify-center overflow-hidden rounded-xl border-2 border-white/30 bg-white/10 px-8 text-base font-bold text-white shadow-lg backdrop-blur-sm transition-all duration-200 hover:scale-[1.03] hover:border-white/50 hover:bg-white/20 hover:shadow-xl active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:h-14 md:px-10 md:text-lg"
+            >
+              방 참가
+            </button>
+          </div>
+
+          {showJoin && (
+            <div className="flex w-full max-w-xs items-center gap-2">
+              <input
+                type="text"
+                value={joinCode}
+                onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                placeholder="방 코드 입력"
+                maxLength={8}
+                className="h-12 flex-1 rounded-xl border border-white/20 bg-white/10 px-4 text-center font-mono text-lg font-bold tracking-[0.2em] text-white placeholder:text-white/30 backdrop-blur-sm outline-none transition focus:border-emerald-400/50 focus:ring-1 focus:ring-emerald-400/30"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleJoin();
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleJoin}
+                disabled={joinCode.trim().length < 4}
+                className="h-12 rounded-xl bg-emerald-500 px-5 text-base font-bold text-white shadow transition hover:bg-emerald-400 active:scale-[0.98] disabled:opacity-40"
+              >
+                참가
+              </button>
+            </div>
+          )}
+
           <Link
             to="/setup"
-            className="group relative inline-flex h-12 items-center justify-center overflow-hidden rounded-xl bg-white px-8 text-base font-bold text-zinc-900 shadow-lg transition-all duration-200 hover:scale-[1.03] hover:shadow-xl active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:h-14 md:px-10 md:text-lg"
+            className="inline-flex h-10 items-center justify-center rounded-lg px-6 text-sm font-medium text-white/60 transition hover:text-white/90"
           >
-            <span className="relative z-10">게임 시작</span>
-            <span className="absolute inset-0 -z-0 bg-gradient-to-r from-emerald-100 via-white to-sky-100 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            로컬 플레이
           </Link>
+
           <span
             className="text-xs tracking-wide text-white/70 md:text-sm"
             style={{ textShadow: "0 1px 2px rgba(0,0,0,0.3)" }}

--- a/apps/web/src/features/mountain-race/screens/LandingScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LandingScreen.tsx
@@ -23,14 +23,14 @@ export function LandingScreen() {
     setCreating(true);
     const code = await createRoom();
     setCreating(false);
-    if (code) void navigate({ to: "/lobby" });
+    if (code) void navigate({ to: "/lobby", search: { code } });
   }, [createRoom, navigate]);
 
   const handleJoin = useCallback(() => {
     const code = joinCode.trim().toUpperCase();
     if (code.length < 4) return;
     joinRoom(code);
-    void navigate({ to: "/lobby" });
+    void navigate({ to: "/lobby", search: { code } });
   }, [joinCode, joinRoom, navigate]);
 
   return (

--- a/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
@@ -178,27 +178,6 @@ export function LobbyScreen() {
             </p>
           )}
 
-          {isHost && (
-            <pre className="mt-2 max-h-32 w-full overflow-auto rounded-lg bg-black/40 p-2 text-left font-mono text-[0.6rem] text-white/50">
-              {JSON.stringify(
-                {
-                  allReady,
-                  playerCount: players.length,
-                  myId: playerId,
-                  hostId: players.find((p) => p.isHost)?.id,
-                  players: players.map((p) => ({
-                    id: p.id.slice(0, 8),
-                    host: p.isHost,
-                    ready: p.ready,
-                    conn: p.connected,
-                  })),
-                },
-                null,
-                1,
-              )}
-            </pre>
-          )}
-
           <button
             type="button"
             onClick={disconnect}

--- a/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
@@ -1,0 +1,192 @@
+import { useConnectionStore } from "@/features/mountain-race/store/useConnectionStore";
+import { useCallback, useRef, useState } from "react";
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="ml-3 rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white/80 backdrop-blur-sm transition hover:bg-white/20 active:scale-95"
+    >
+      {copied ? "복사됨!" : "복사"}
+    </button>
+  );
+}
+
+function PlayerRow({
+  name,
+  jacketColor,
+  ready,
+  isMe,
+  isHost,
+  onNameChange,
+}: {
+  name: string;
+  jacketColor: string;
+  ready: boolean;
+  isMe: boolean;
+  isHost: boolean;
+  onNameChange?: ((v: string) => void) | undefined;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-white/5 px-4 py-3 backdrop-blur-sm">
+      <span
+        className="size-4 shrink-0 rounded-full ring-2 ring-white/20"
+        style={{ backgroundColor: jacketColor }}
+      />
+
+      {isMe ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={name}
+          maxLength={12}
+          onChange={(e) => onNameChange?.(e.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-sm font-medium text-white outline-none transition focus:border-emerald-400/50 focus:ring-1 focus:ring-emerald-400/30"
+        />
+      ) : (
+        <span className="flex-1 truncate text-sm font-medium text-white/90">{name}</span>
+      )}
+
+      <div className="flex items-center gap-2">
+        {isHost && (
+          <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-[0.65rem] font-semibold tracking-wide text-amber-300 uppercase">
+            호스트
+          </span>
+        )}
+        <span
+          className={`size-2.5 rounded-full transition ${ready ? "bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]" : "bg-white/20"}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function LobbyScreen() {
+  const { roomCode, players, playerId, isHost, status, send, disconnect } = useConnectionStore();
+
+  const me = players.find((p) => p.id === playerId);
+  const allReady = players.length >= 2 && players.every((p) => p.ready);
+
+  const handleNameChange = useCallback(
+    (name: string) => {
+      send({
+        type: "setCharacter",
+        name,
+        faceImage: null,
+        color: me?.color ?? {
+          jacket: "#3b82f6",
+          inner: "#fff",
+          pants: "#1e293b",
+          buff: "#f97316",
+          hat: "#22c55e",
+        },
+      });
+    },
+    [send, me?.color],
+  );
+
+  const toggleReady = useCallback(() => {
+    send({ type: "setReady", ready: !me?.ready });
+  }, [send, me?.ready]);
+
+  const startRace = useCallback(() => {
+    send({ type: "startRace" });
+  }, [send]);
+
+  return (
+    <main className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden bg-linear-to-b from-slate-900 via-slate-800 to-slate-900 px-4 py-8">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(52,211,153,0.05)_0%,transparent_70%)]" />
+
+      <div className="relative z-10 flex w-full max-w-md flex-col items-center gap-8">
+        {/* room code */}
+        <div className="flex flex-col items-center gap-2">
+          <span className="text-xs font-semibold tracking-[0.2em] text-white/50 uppercase">
+            방 코드
+          </span>
+          <div className="flex items-center">
+            <span className="font-mono text-4xl font-black tracking-[0.25em] text-white md:text-5xl">
+              {roomCode ?? "----"}
+            </span>
+            {roomCode && <CopyButton text={roomCode} />}
+          </div>
+        </div>
+
+        {/* status */}
+        {status === "connecting" && <p className="animate-pulse text-sm text-white/60">연결 중…</p>}
+        {status === "error" && (
+          <p className="text-sm text-red-400">연결 오류. 다시 시도해 주세요.</p>
+        )}
+
+        {/* player list */}
+        <div className="w-full space-y-2">
+          <h2 className="mb-3 text-center text-sm font-semibold tracking-wide text-white/60 uppercase">
+            플레이어 ({players.length})
+          </h2>
+          {players.map((p) => (
+            <PlayerRow
+              key={p.id}
+              name={p.name}
+              jacketColor={p.color.jacket}
+              ready={p.ready}
+              isMe={p.id === playerId}
+              isHost={p.isHost}
+              onNameChange={p.id === playerId ? handleNameChange : undefined}
+            />
+          ))}
+        </div>
+
+        {/* actions */}
+        <div className="flex w-full flex-col gap-3">
+          {isHost ? (
+            <button
+              type="button"
+              onClick={startRace}
+              disabled={!allReady}
+              className="h-12 w-full rounded-xl bg-emerald-500 text-base font-bold text-white shadow-lg transition hover:bg-emerald-400 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 md:h-14 md:text-lg"
+            >
+              레이스 시작
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={toggleReady}
+              className={`h-12 w-full rounded-xl text-base font-bold shadow-lg transition active:scale-[0.98] md:h-14 md:text-lg ${
+                me?.ready
+                  ? "bg-white/10 text-white/80 hover:bg-white/20"
+                  : "bg-emerald-500 text-white hover:bg-emerald-400"
+              }`}
+            >
+              {me?.ready ? "준비 취소" : "준비 완료"}
+            </button>
+          )}
+
+          {!allReady && isHost && (
+            <p className="text-center text-xs text-white/40">
+              모든 플레이어가 준비해야 시작할 수 있습니다 (최소 2명)
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={disconnect}
+            className="h-10 w-full rounded-xl border border-white/10 text-sm font-medium text-white/50 transition hover:border-white/20 hover:text-white/70"
+          >
+            나가기
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
@@ -77,7 +77,7 @@ export function LobbyScreen() {
   const { roomCode, players, playerId, isHost, status, send, disconnect } = useConnectionStore();
 
   const me = players.find((p) => p.id === playerId);
-  const allReady = players.length >= 2 && players.every((p) => p.ready);
+  const allReady = players.length >= 2 && players.filter((p) => !p.isHost).every((p) => p.ready);
 
   const handleNameChange = useCallback(
     (name: string) => {

--- a/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/LobbyScreen.tsx
@@ -178,6 +178,27 @@ export function LobbyScreen() {
             </p>
           )}
 
+          {isHost && (
+            <pre className="mt-2 max-h-32 w-full overflow-auto rounded-lg bg-black/40 p-2 text-left font-mono text-[0.6rem] text-white/50">
+              {JSON.stringify(
+                {
+                  allReady,
+                  playerCount: players.length,
+                  myId: playerId,
+                  hostId: players.find((p) => p.isHost)?.id,
+                  players: players.map((p) => ({
+                    id: p.id.slice(0, 8),
+                    host: p.isHost,
+                    ready: p.ready,
+                    conn: p.connected,
+                  })),
+                },
+                null,
+                1,
+              )}
+            </pre>
+          )}
+
           <button
             type="button"
             onClick={disconnect}

--- a/apps/web/src/features/mountain-race/screens/index.ts
+++ b/apps/web/src/features/mountain-race/screens/index.ts
@@ -1,4 +1,5 @@
 export { LandingScreen } from "./LandingScreen";
+export { LobbyScreen } from "./LobbyScreen";
 export { SetupScreen } from "./SetupScreen";
 export { RaceScreen } from "./RaceScreen";
 export { ResultScreen } from "./ResultScreen";

--- a/apps/web/src/features/mountain-race/store/index.ts
+++ b/apps/web/src/features/mountain-race/store/index.ts
@@ -1,2 +1,3 @@
 export { useAudioStore } from "./useAudioStore";
+export { useConnectionStore } from "./useConnectionStore";
 export { useGameStore } from "./useGameStore";

--- a/apps/web/src/features/mountain-race/store/useConnectionStore.ts
+++ b/apps/web/src/features/mountain-race/store/useConnectionStore.ts
@@ -111,18 +111,13 @@ function handleServerMessage(msg: ServerMessage, set: SetState, get: GetState): 
       set({
         players: msg.state.players,
         phase: msg.state.phase,
-        playerId: get().playerId ?? msg.state.players[msg.state.players.length - 1]?.id ?? null,
-        isHost:
-          msg.state.hostId ===
-          (get().playerId ?? msg.state.players[msg.state.players.length - 1]?.id),
+        playerId: msg.yourPlayerId,
+        isHost: msg.state.hostId === msg.yourPlayerId,
       });
       break;
 
     case "playerJoined":
       set({ players: [...get().players, msg.player] });
-      if (!get().playerId) {
-        set({ playerId: msg.player.id, isHost: msg.player.isHost });
-      }
       break;
 
     case "playerLeft":

--- a/apps/web/src/features/mountain-race/store/useConnectionStore.ts
+++ b/apps/web/src/features/mountain-race/store/useConnectionStore.ts
@@ -1,0 +1,165 @@
+import { create } from "zustand";
+import type { ClientMessage, Player, RoomState, ServerMessage } from "@mountain-race/types";
+
+type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
+
+interface ConnectionState {
+  status: ConnectionStatus;
+  ws: WebSocket | null;
+  roomCode: string | null;
+  playerId: string | null;
+  isHost: boolean;
+  players: Player[];
+  phase: RoomState["phase"] | null;
+  hasHiddenEffect: boolean;
+
+  createRoom: () => Promise<string | null>;
+  joinRoom: (code: string) => void;
+  disconnect: () => void;
+  send: (msg: ClientMessage) => void;
+}
+
+const API_URL =
+  (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_URL) || "http://localhost:8787";
+
+function wsUrl(code: string): string {
+  const base = API_URL.replace(/^http/, "ws");
+  return `${base}/rooms/${code}/ws`;
+}
+
+export const useConnectionStore = create<ConnectionState>((set, get) => ({
+  status: "disconnected",
+  ws: null,
+  roomCode: null,
+  playerId: null,
+  isHost: false,
+  players: [],
+  phase: null,
+  hasHiddenEffect: false,
+
+  createRoom: async () => {
+    try {
+      const res = await fetch(`${API_URL}/rooms`, { method: "POST" });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { roomCode: string };
+      get().joinRoom(data.roomCode);
+      return data.roomCode;
+    } catch {
+      return null;
+    }
+  },
+
+  joinRoom: (code: string) => {
+    const prev = get().ws;
+    if (prev) prev.close();
+
+    set({ status: "connecting", roomCode: code });
+
+    const ws = new WebSocket(wsUrl(code));
+
+    ws.onopen = () => {
+      set({ status: "connected", ws });
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string) as ServerMessage;
+        handleServerMessage(msg, set, get);
+      } catch {
+        /* malformed */
+      }
+    };
+
+    ws.onclose = () => {
+      set({ status: "disconnected", ws: null });
+    };
+
+    ws.onerror = () => {
+      set({ status: "error", ws: null });
+    };
+  },
+
+  disconnect: () => {
+    const { ws } = get();
+    if (ws) ws.close();
+    set({
+      status: "disconnected",
+      ws: null,
+      roomCode: null,
+      playerId: null,
+      isHost: false,
+      players: [],
+      phase: null,
+      hasHiddenEffect: false,
+    });
+  },
+
+  send: (msg: ClientMessage) => {
+    const { ws } = get();
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  },
+}));
+
+type SetState = (partial: Partial<ConnectionState>) => void;
+type GetState = () => ConnectionState;
+
+function handleServerMessage(msg: ServerMessage, set: SetState, get: GetState): void {
+  switch (msg.type) {
+    case "roomState":
+      set({
+        players: msg.state.players,
+        phase: msg.state.phase,
+        playerId: get().playerId ?? msg.state.players[msg.state.players.length - 1]?.id ?? null,
+        isHost:
+          msg.state.hostId ===
+          (get().playerId ?? msg.state.players[msg.state.players.length - 1]?.id),
+      });
+      break;
+
+    case "playerJoined":
+      set({ players: [...get().players, msg.player] });
+      if (!get().playerId) {
+        set({ playerId: msg.player.id, isHost: msg.player.isHost });
+      }
+      break;
+
+    case "playerLeft":
+      set({
+        players: get().players.filter((p) => p.id !== msg.playerId),
+      });
+      break;
+
+    case "playerUpdated": {
+      const players = get().players.map((p) =>
+        p.id === msg.playerId ? { ...p, ...msg.changes } : p,
+      );
+      set({ players });
+      const me = players.find((p) => p.id === get().playerId);
+      if (me) set({ isHost: me.isHost });
+      break;
+    }
+
+    case "countdown":
+      set({ phase: "countdown" });
+      break;
+
+    case "hasHiddenEffect":
+      set({ hasHiddenEffect: msg.hasEffect });
+      break;
+
+    case "raceResult":
+      set({ phase: "result" });
+      break;
+
+    case "gameTick":
+      if (get().phase !== "racing") {
+        set({ phase: "racing" });
+      }
+      break;
+
+    default:
+      break;
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as ResultRouteImport } from './routes/result'
 import { Route as RaceRouteImport } from './routes/race'
+import { Route as LobbyRouteImport } from './routes/lobby'
 import { Route as IndexRouteImport } from './routes/index'
 
 const SetupRoute = SetupRouteImport.update({
@@ -29,6 +30,11 @@ const RaceRoute = RaceRouteImport.update({
   path: '/race',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LobbyRoute = LobbyRouteImport.update({
+  id: '/lobby',
+  path: '/lobby',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -37,12 +43,14 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/lobby': typeof LobbyRoute
   '/race': typeof RaceRoute
   '/result': typeof ResultRoute
   '/setup': typeof SetupRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/lobby': typeof LobbyRoute
   '/race': typeof RaceRoute
   '/result': typeof ResultRoute
   '/setup': typeof SetupRoute
@@ -50,20 +58,22 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/lobby': typeof LobbyRoute
   '/race': typeof RaceRoute
   '/result': typeof ResultRoute
   '/setup': typeof SetupRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/race' | '/result' | '/setup'
+  fullPaths: '/' | '/lobby' | '/race' | '/result' | '/setup'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/race' | '/result' | '/setup'
-  id: '__root__' | '/' | '/race' | '/result' | '/setup'
+  to: '/' | '/lobby' | '/race' | '/result' | '/setup'
+  id: '__root__' | '/' | '/lobby' | '/race' | '/result' | '/setup'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LobbyRoute: typeof LobbyRoute
   RaceRoute: typeof RaceRoute
   ResultRoute: typeof ResultRoute
   SetupRoute: typeof SetupRoute
@@ -92,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/lobby': {
+      id: '/lobby'
+      path: '/lobby'
+      fullPath: '/lobby'
+      preLoaderRoute: typeof LobbyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +121,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LobbyRoute: LobbyRoute,
   RaceRoute: RaceRoute,
   ResultRoute: ResultRoute,
   SetupRoute: SetupRoute,

--- a/apps/web/src/routes/lobby.tsx
+++ b/apps/web/src/routes/lobby.tsx
@@ -4,13 +4,30 @@ import { useConnectionStore } from "@/features/mountain-race/store/useConnection
 import { markSetupComplete } from "@/features/mountain-race";
 import { useEffect } from "react";
 
+interface LobbySearch {
+  code?: string | undefined;
+}
+
 export const Route = createFileRoute("/lobby")({
+  validateSearch: (search: Record<string, unknown>): LobbySearch => ({
+    code: typeof search.code === "string" ? search.code.toUpperCase() : undefined,
+  }),
   component: LobbyRoute,
 });
 
 function LobbyRoute() {
+  const { code } = Route.useSearch();
   const phase = useConnectionStore((s) => s.phase);
+  const status = useConnectionStore((s) => s.status);
+  const roomCode = useConnectionStore((s) => s.roomCode);
+  const joinRoom = useConnectionStore((s) => s.joinRoom);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (code && status === "disconnected" && !roomCode) {
+      joinRoom(code);
+    }
+  }, [code, status, roomCode, joinRoom]);
 
   useEffect(() => {
     if (phase === "countdown" || phase === "racing") {

--- a/apps/web/src/routes/lobby.tsx
+++ b/apps/web/src/routes/lobby.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { LobbyScreen } from "@/features/mountain-race/screens";
+import { useConnectionStore } from "@/features/mountain-race/store/useConnectionStore";
+import { markSetupComplete } from "@/features/mountain-race";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/lobby")({
+  component: LobbyRoute,
+});
+
+function LobbyRoute() {
+  const phase = useConnectionStore((s) => s.phase);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (phase === "countdown" || phase === "racing") {
+      markSetupComplete();
+      void navigate({ to: "/race" });
+    }
+  }, [phase, navigate]);
+
+  return <LobbyScreen />;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -191,7 +191,7 @@ export type ClientMessage =
   | { type: "activateEffect" };
 
 export type ServerMessage =
-  | { type: "roomState"; state: RoomState }
+  | { type: "roomState"; state: RoomState; yourPlayerId: string }
   | { type: "playerJoined"; player: Player }
   | { type: "playerLeft"; playerId: string }
   | { type: "playerUpdated"; playerId: string; changes: Partial<Player> }


### PR DESCRIPTION
## Summary
- `useConnectionStore`: Zustand WebSocket 연결 관리 — 방 생성(POST /rooms), 방 참가(WS 연결), 서버 메시지 핸들링
- `LobbyScreen`: 방 코드 표시+복사, 실시간 플레이어 목록, 이름 편집, 준비 토글, 호스트 시작 버튼
- `/lobby` 라우트: countdown/racing phase 전환 시 자동으로 `/race` 이동
- `LandingScreen`: CTA를 "방 만들기" / "방 참가" (코드 입력) / "로컬 플레이"로 분리

## Verification
- [x] `pnpm check` 전체 통과
- [x] 빌드 성공 (`lobby-CVqvS4qv.js` 코드 스플릿 자동 적용)

## Next
- Phase 6: 레이스 화면 서버 동기화 + 효과 발동 버튼 UI + 결과 확장


Made with [Cursor](https://cursor.com)