### PR TITLE
Phase 6: Race sync + hidden effect activation UI + result cards

### DIFF
--- a/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
+++ b/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
@@ -88,7 +88,13 @@ export function RaceRouteComposition() {
 
 function MultiplayerCountdown() {
   const serverPhase = useConnectionStore((s) => s.phase);
+  const myPlayerId = useConnectionStore((s) => s.playerId);
+  const setCameraTarget = useGameStore((s) => s.setCameraTarget);
   const [countdownPhase, setCountdownPhase] = useState(COUNTDOWN_SECONDS);
+
+  useEffect(() => {
+    if (myPlayerId) setCameraTarget(myPlayerId);
+  }, [myPlayerId, setCameraTarget]);
 
   useEffect(() => {
     if (serverPhase !== "countdown") return;

--- a/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
+++ b/apps/web/src/features/mountain-race/app/RaceRouteComposition.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { InGameOverlaySlot, RaceSceneSlot } from "@/features/mountain-race/components";
 import { COUNTDOWN_SECONDS } from "@/features/mountain-race/constants/balance";
-import { useAudioStore, useGameStore } from "@/features/mountain-race/store";
+import { useAudioStore, useConnectionStore, useGameStore } from "@/features/mountain-race/store";
 
 // ── Web Audio beep (no external files needed) ──────────────────────────────
 
@@ -73,13 +73,68 @@ function CountdownOverlay({ phase }: { phase: number }) {
 // ── Main composition ───────────────────────────────────────────────────────
 
 export function RaceRouteComposition() {
+  const isMultiplayer = useConnectionStore((s) => s.status === "connected");
+
+  return (
+    <main className="relative h-dvh w-full overflow-hidden p-0">
+      <RaceSceneSlot />
+      <InGameOverlaySlot />
+      {isMultiplayer ? <MultiplayerCountdown /> : <LocalRaceLoop />}
+    </main>
+  );
+}
+
+// ── Multiplayer: server drives countdown + game ticks ─────────────────────
+
+function MultiplayerCountdown() {
+  const serverPhase = useConnectionStore((s) => s.phase);
+  const [countdownPhase, setCountdownPhase] = useState(COUNTDOWN_SECONDS);
+
+  useEffect(() => {
+    if (serverPhase !== "countdown") return;
+    playCountdownBeep(BEEP_FREQ_TICK, BEEP_DUR_TICK);
+    setCountdownPhase(COUNTDOWN_SECONDS);
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (let i = 1; i <= COUNTDOWN_SECONDS; i++) {
+      timers.push(
+        setTimeout(() => {
+          const next = COUNTDOWN_SECONDS - i;
+          setCountdownPhase(next);
+          playCountdownBeep(
+            next > 0 ? BEEP_FREQ_TICK : BEEP_FREQ_GO,
+            next > 0 ? BEEP_DUR_TICK : BEEP_DUR_GO,
+          );
+        }, i * 1000),
+      );
+    }
+    return () => timers.forEach(clearTimeout);
+  }, [serverPhase]);
+
+  useEffect(() => {
+    if (countdownPhase !== 0) return;
+    const timer = setTimeout(() => setCountdownPhase(-1), GO_DISPLAY_MS);
+    return () => clearTimeout(timer);
+  }, [countdownPhase]);
+
+  if (serverPhase === "racing" || serverPhase === "result") {
+    return null;
+  }
+  if (countdownPhase >= 0) {
+    return <CountdownOverlay phase={countdownPhase} />;
+  }
+  return null;
+}
+
+// ── Local mode: existing countdown + RAF tick loop ────────────────────────
+
+function LocalRaceLoop() {
   const startRace = useGameStore((s) => s.startRace);
   const tick = useGameStore((s) => s.tick);
   const isRacing = useGameStore((s) => s.isRacing);
   const [countdownPhase, setCountdownPhase] = useState(COUNTDOWN_SECONDS);
   const raceStarted = useRef(false);
 
-  // Countdown sequence: 3 → 2 → 1 → 0 ("출발!")
   useEffect(() => {
     playCountdownBeep(BEEP_FREQ_TICK, BEEP_DUR_TICK);
 
@@ -100,14 +155,12 @@ export function RaceRouteComposition() {
     return () => timers.forEach(clearTimeout);
   }, []);
 
-  // Trigger race start when countdown reaches 0
   useEffect(() => {
     if (countdownPhase > 0 || raceStarted.current) return;
     raceStarted.current = true;
     startRace();
   }, [countdownPhase, startRace]);
 
-  // RAF game loop — independent of countdownPhase so the "출발!" hide doesn't kill it
   useEffect(() => {
     if (!isRacing) return;
 
@@ -129,18 +182,11 @@ export function RaceRouteComposition() {
     return () => window.cancelAnimationFrame(rafId);
   }, [isRacing, tick]);
 
-  // Auto-hide "출발!" after a short display
   useEffect(() => {
     if (countdownPhase !== 0) return;
     const timer = setTimeout(() => setCountdownPhase(-1), GO_DISPLAY_MS);
     return () => clearTimeout(timer);
   }, [countdownPhase]);
 
-  return (
-    <main className="relative h-dvh w-full overflow-hidden p-0">
-      <RaceSceneSlot />
-      <InGameOverlaySlot />
-      {countdownPhase >= 0 && <CountdownOverlay phase={countdownPhase} />}
-    </main>
-  );
+  return countdownPhase >= 0 ? <CountdownOverlay phase={countdownPhase} /> : null;
 }

--- a/apps/web/src/features/mountain-race/components/EffectRevealOverlay.tsx
+++ b/apps/web/src/features/mountain-race/components/EffectRevealOverlay.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+import type { HiddenEffectCategory } from "@mountain-race/types";
+import { useConnectionStore } from "../store/useConnectionStore";
+import { useGameStore } from "../store/useGameStore";
+
+const AUTO_HIDE_MS = 3000;
+
+const CATEGORY_BORDER: Record<HiddenEffectCategory, string> = {
+  good: "border-emerald-400",
+  bad: "border-red-400",
+  wildcard: "border-purple-400",
+};
+
+export function EffectRevealOverlay() {
+  const lastReveal = useConnectionStore((s) => s.lastEffectReveal);
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevRevealRef = useRef(lastReveal);
+
+  useEffect(() => {
+    if (!lastReveal || lastReveal === prevRevealRef.current) return;
+    prevRevealRef.current = lastReveal;
+    setVisible(true);
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      useConnectionStore.setState({ lastEffectReveal: null });
+    }, AUTO_HIDE_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [lastReveal]);
+
+  if (!visible || !lastReveal) return null;
+
+  const { characters } = useGameStore.getState();
+  const playerName =
+    lastReveal.targetName ?? characters.find((c) => c.id === lastReveal.playerId)?.name ?? "???";
+  const { effect } = lastReveal;
+
+  return (
+    <div className="absolute inset-0 z-40 flex items-center justify-center">
+      <div
+        className={`animate-in fade-in-0 zoom-in-75 rounded-2xl border-2 ${CATEGORY_BORDER[effect.category]} bg-black/60 px-8 py-5 text-center backdrop-blur-md duration-300`}
+      >
+        <p className="text-2xl font-bold text-white md:text-3xl">🎲 {playerName}의 비밀 효과</p>
+        <p className="mt-2 text-xl font-bold text-white/90 md:text-2xl">
+          {effect.emoji} {effect.name}!
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/HiddenEffectButton.tsx
+++ b/apps/web/src/features/mountain-race/components/HiddenEffectButton.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { useConnectionStore } from "../store/useConnectionStore";
+
+export function HiddenEffectButton() {
+  const hasHiddenEffect = useConnectionStore((s) => s.hasHiddenEffect);
+  const send = useConnectionStore((s) => s.send);
+  const [activated, setActivated] = useState(false);
+
+  if (!hasHiddenEffect || activated) return null;
+
+  const handleClick = () => {
+    send({ type: "activateEffect" });
+    setActivated(true);
+  };
+
+  return (
+    <>
+      <style>{`
+        @keyframes mr-pulse-effect {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.05); }
+        }
+      `}</style>
+      <div className="pointer-events-none absolute inset-x-0 bottom-8 z-30 flex justify-center">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="pointer-events-auto flex h-16 w-16 items-center justify-center rounded-full bg-black/60 text-2xl font-black text-white shadow-lg backdrop-blur-md transition-colors hover:bg-black/70 active:scale-95"
+          style={{ animation: "mr-pulse-effect 2s ease-in-out infinite" }}
+          aria-label="숨겨진 효과 발동"
+        >
+          ?
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
+++ b/apps/web/src/features/mountain-race/components/InGameOverlaySlot.tsx
@@ -1,14 +1,19 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { markResultReady } from "@/features/mountain-race/app";
-import { useGameStore } from "@/features/mountain-race/store";
+import { useConnectionStore, useGameStore } from "@/features/mountain-race/store";
 import { CameraControls } from "./CameraControls";
+import { EffectRevealOverlay } from "./EffectRevealOverlay";
 import { HUD } from "./HUD";
 import { EventAlert } from "./EventAlert";
 import { EventLog } from "./EventLog";
+import { HiddenEffectButton } from "./HiddenEffectButton";
 
 export function InGameOverlaySlot() {
-  const hasResult = useGameStore((s) => s.hasResult);
+  const localHasResult = useGameStore((s) => s.hasResult);
+  const isMultiplayer = useConnectionStore((s) => s.status === "connected");
+  const mpPhase = useConnectionStore((s) => s.phase);
+  const hasResult = isMultiplayer ? mpPhase === "result" || localHasResult : localHasResult;
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -23,6 +28,8 @@ export function InGameOverlaySlot() {
       <EventAlert />
       <EventLog />
       <CameraControls />
+      {isMultiplayer && <HiddenEffectButton />}
+      {isMultiplayer && <EffectRevealOverlay />}
     </aside>
   );
 }

--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -3,8 +3,9 @@ import { Canvas } from "@react-three/fiber";
 import { useMemo } from "react";
 import { resetRouteGuardSnapshot } from "@/features/mountain-race/app";
 import { FINISH_LINE } from "@/features/mountain-race/constants/balance";
+import { useConnectionStore } from "@/features/mountain-race/store/useConnectionStore";
 import { useGameStore } from "@/features/mountain-race/store/useGameStore";
-import type { Character, GameEvent } from "@/features/mountain-race/types";
+import type { Character, GameEvent, HiddenEffectAssignment } from "@/features/mountain-race/types";
 import { ResultScene } from "./ResultScene";
 
 const RANK_MEDALS = ["🥇", "🥈", "🥉"] as const;
@@ -52,6 +53,7 @@ export function ResultScreen() {
   const rankings = useGameStore((s) => s.rankings);
   const events = useGameStore((s) => s.events);
   const resetGame = useGameStore((s) => s.resetGame);
+  const raceHiddenEffects = useConnectionStore((s) => s.raceHiddenEffects);
 
   const rankedCharacters = useMemo(() => {
     const charMap = new Map(characters.map((c) => [c.id, c]));
@@ -285,10 +287,15 @@ export function ResultScreen() {
             </div>
           ) : null}
 
+          {/* hidden effects */}
+          {raceHiddenEffects.length > 0 && (
+            <HiddenEffectsSection effects={raceHiddenEffects} characters={characters} />
+          )}
+
           {/* action buttons */}
           <div
             className="mr-result-stagger flex items-center justify-center gap-3"
-            style={{ animationDelay: "600ms" }}
+            style={{ animationDelay: "750ms" }}
           >
             <button
               type="button"
@@ -309,5 +316,81 @@ export function ResultScreen() {
         </div>
       </div>
     </main>
+  );
+}
+
+// ── Hidden Effects Section ──────────────────────────────────────────────────
+
+function getUnusedLabel(
+  assignment: HiddenEffectAssignment,
+): { text: string; className: string } | null {
+  if (assignment.activated) return null;
+  switch (assignment.effect.category) {
+    case "good":
+      return { text: "아깝다!", className: "bg-yellow-500/80 text-yellow-950" };
+    case "bad":
+      return { text: "현명한 선택!", className: "bg-emerald-500/80 text-emerald-950" };
+    case "wildcard":
+      return { text: "모험을 두려워하다니...", className: "bg-purple-500/80 text-purple-950" };
+  }
+}
+
+function HiddenEffectsSection({
+  effects,
+  characters,
+}: {
+  effects: HiddenEffectAssignment[];
+  characters: Character[];
+}) {
+  const charMap = new Map(characters.map((c) => [c.id, c]));
+
+  return (
+    <div className="mr-result-stagger mb-6" style={{ animationDelay: "600ms" }}>
+      <p
+        className="mb-2 text-center text-xs font-semibold tracking-wide text-white/50 uppercase"
+        style={{ textShadow: "0 1px 2px rgba(0,0,0,0.3)" }}
+      >
+        🎲 숨겨진 효과
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {effects.map((a) => {
+          const char = charMap.get(a.playerId);
+          const unusedLabel = getUnusedLabel(a);
+          return (
+            <div
+              key={a.playerId}
+              className="flex items-center gap-3 rounded-xl border border-white/15 bg-black/25 px-3.5 py-3 backdrop-blur-md"
+            >
+              <span className="text-2xl">{a.effect.emoji}</span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-bold text-white/90">
+                  {char?.name ?? a.playerId}
+                </p>
+                <p className="text-[0.65rem] font-semibold text-white/60">{a.effect.name}</p>
+                <p className="text-[0.6rem] text-white/40">{a.effect.description}</p>
+              </div>
+              {a.activated ? (
+                <span className="shrink-0 rounded-full bg-red-500/80 px-2 py-0.5 text-[0.6rem] font-bold text-white">
+                  발동!
+                </span>
+              ) : (
+                <div className="flex shrink-0 flex-col items-end gap-0.5">
+                  <span className="rounded-full bg-white/15 px-2 py-0.5 text-[0.6rem] font-bold text-white/60">
+                    미사용
+                  </span>
+                  {unusedLabel && (
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[0.55rem] font-bold ${unusedLabel.className}`}
+                    >
+                      {unusedLabel.text}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/features/mountain-race/store/useConnectionStore.ts
+++ b/apps/web/src/features/mountain-race/store/useConnectionStore.ts
@@ -1,5 +1,13 @@
 import { create } from "zustand";
-import type { ClientMessage, Player, RoomState, ServerMessage } from "@mountain-race/types";
+import type {
+  ClientMessage,
+  HiddenEffect,
+  HiddenEffectAssignment,
+  Player,
+  RoomState,
+  ServerMessage,
+} from "@mountain-race/types";
+import { useGameStore } from "./useGameStore";
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
 
@@ -12,6 +20,8 @@ interface ConnectionState {
   players: Player[];
   phase: RoomState["phase"] | null;
   hasHiddenEffect: boolean;
+  lastEffectReveal: { playerId: string; effect: HiddenEffect; targetName?: string } | null;
+  raceHiddenEffects: HiddenEffectAssignment[];
 
   createRoom: () => Promise<string | null>;
   joinRoom: (code: string) => void;
@@ -36,6 +46,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   players: [],
   phase: null,
   hasHiddenEffect: false,
+  lastEffectReveal: null,
+  raceHiddenEffects: [],
 
   createRoom: async () => {
     try {
@@ -91,6 +103,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       players: [],
       phase: null,
       hasHiddenEffect: false,
+      lastEffectReveal: null,
+      raceHiddenEffects: [],
     });
   },
 
@@ -144,14 +158,42 @@ function handleServerMessage(msg: ServerMessage, set: SetState, get: GetState): 
       set({ hasHiddenEffect: msg.hasEffect });
       break;
 
+    case "effectReveal": {
+      const reveal: ConnectionState["lastEffectReveal"] = {
+        playerId: msg.playerId,
+        effect: msg.effect,
+      };
+      if (msg.targetName !== undefined) reveal.targetName = msg.targetName;
+      set({ lastEffectReveal: reveal });
+      break;
+    }
+
     case "raceResult":
-      set({ phase: "result" });
+      set({ phase: "result", raceHiddenEffects: msg.hiddenEffects });
+      useGameStore.setState({
+        isRacing: false,
+        hasResult: true,
+        rankings: msg.rankings,
+        characters: msg.characters,
+      });
       break;
 
     case "gameTick":
       if (get().phase !== "racing") {
         set({ phase: "racing" });
       }
+      useGameStore.setState({
+        characters: msg.characters,
+        rankings: msg.rankings,
+        finishedIds: msg.finishedIds,
+        elapsedTime: msg.elapsedTime,
+        activeGlobalEvent: msg.activeGlobalEvent,
+        events: msg.events,
+        eventLogs: msg.eventLogs,
+        activeBubble: msg.activeBubble,
+        isRacing: true,
+        hasResult: false,
+      });
       break;
 
     default:


### PR DESCRIPTION
## Summary
- **레이스 동기화**: 멀티플레이 시 서버 `gameTick` 메시지로 `useGameStore` 상태 동기화, 로컬 RAF tick 비활성화
- **"? 발동" 버튼**: HUD 하단 펄스 애니메이션, 클릭 시 `activateEffect` → 버튼 소멸
- **효과 공개 오버레이**: `EffectReveal` 수신 시 전체 화면 연출 (카테고리별 색상, 3초 자동 해제)
- **결과 화면 확장**: "숨겨진 효과" 섹션 — 각 플레이어 배정 효과, 사용/미사용 배지, 카테고리별 라벨
- **로컬 모드 보존**: 모든 멀티플레이 경로는 `connectionStore.status === "connected"` 게이트

## New Files
- `HiddenEffectButton.tsx` — "?" 발동 버튼 컴포넌트
- `EffectRevealOverlay.tsx` — 효과 공개 오버레이 컴포넌트

## Modified Files
- `useConnectionStore.ts` — gameTick/effectReveal/raceResult → useGameStore 동기화
- `RaceRouteComposition.tsx` — 멀티플레이/로컬 분기 (MultiplayerCountdown vs LocalRaceLoop)
- `InGameOverlaySlot.tsx` — 멀티플레이 시 발동 버튼 + 공개 오버레이 통합
- `ResultScreen.tsx` — 숨겨진 효과 공개 카드 섹션

## Verification
- [x] `pnpm check` 전체 통과
- [ ] 프리뷰에서 멀티플레이 레이스 + 효과 발동 + 결과 E2E 확인

## Next
- Phase 7: 로컬 모드 유지 + 통합 검증


Made with [Cursor](https://cursor.com)