### PR TITLE
fix: PR #40 review feedback — shield, routing, effects, collision

### DIFF
--- a/apps/api/src/domain/effects/badEffects.ts
+++ b/apps/api/src/domain/effects/badEffects.ts
@@ -3,6 +3,10 @@ import type { EffectContext, EffectHandler, EffectResult } from "./effectHandler
 export const selfTripEffect: EffectHandler = {
   apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
     const updated = [...characters];
+    if (caster.status === "shielded") {
+      updated[casterIndex] = { ...caster, status: "running" };
+      return { characters: updated };
+    }
     updated[casterIndex] = {
       ...caster,
       status: "stunned",
@@ -17,6 +21,10 @@ export const selfTripEffect: EffectHandler = {
 export const ankleWeightEffect: EffectHandler = {
   apply({ casterIndex, caster, characters, elapsedTime }: EffectContext): EffectResult {
     const updated = [...characters];
+    if (caster.status === "shielded") {
+      updated[casterIndex] = { ...caster, status: "running" };
+      return { characters: updated };
+    }
     updated[casterIndex] = {
       ...caster,
       status: "slowed",

--- a/apps/api/src/domain/effects/badEffects.ts
+++ b/apps/api/src/domain/effects/badEffects.ts
@@ -31,20 +31,21 @@ export const magnetEffect: EffectHandler = {
   apply({ casterIndex, caster, characters, rankings }: EffectContext): EffectResult {
     const updated = [...characters];
     const rankIndex = rankings.indexOf(caster.id);
-    const secondPlaceId = rankings[1];
 
-    if (rankIndex > 0 && secondPlaceId) {
-      const second = updated.find((c) => c.id === secondPlaceId);
-      if (second) {
-        const pullback = Math.abs(caster.progress - second.progress) * 0.5;
-        updated[casterIndex] = {
-          ...caster,
-          progress: Math.max(0, caster.progress - pullback),
-          stats: { ...caster.stats, setbackTotal: caster.stats.setbackTotal + pullback },
-        };
-      }
-    }
+    if (rankIndex <= 0) return { characters: updated };
 
+    const aheadId = rankings[rankIndex - 1];
+    if (!aheadId) return { characters: updated };
+
+    const ahead = updated.find((c) => c.id === aheadId);
+    if (!ahead) return { characters: updated };
+
+    const pullback = Math.abs(caster.progress - ahead.progress) * 0.5;
+    updated[casterIndex] = {
+      ...caster,
+      progress: Math.max(0, caster.progress - pullback),
+      stats: { ...caster.stats, setbackTotal: caster.stats.setbackTotal + pullback },
+    };
     return { characters: updated };
   },
 };

--- a/apps/api/src/domain/effects/goodEffects.ts
+++ b/apps/api/src/domain/effects/goodEffects.ts
@@ -31,7 +31,7 @@ export const shieldEffect: EffectHandler = {
     const updated = [...characters];
     updated[casterIndex] = {
       ...caster,
-      stats: { ...caster.stats, hitCount: caster.stats.hitCount - 1 },
+      status: "shielded",
     };
     return { characters: updated };
   },

--- a/apps/api/src/domain/effects/wildcardEffects.ts
+++ b/apps/api/src/domain/effects/wildcardEffects.ts
@@ -35,6 +35,9 @@ export const earthquakeEffect: EffectHandler = {
   apply({ characters, elapsedTime }: EffectContext): EffectResult {
     const updated = characters.map((c) => {
       if (c.finishTime !== null) return c;
+      if (c.status === "shielded") {
+        return { ...c, status: "running" as const };
+      }
       return {
         ...c,
         status: "stunned" as const,

--- a/apps/api/src/domain/raceSimulation.ts
+++ b/apps/api/src/domain/raceSimulation.ts
@@ -135,6 +135,10 @@ export class RaceSimulation {
     return { assignment, targetName: result.targetName };
   }
 
+  pushEventLog(log: EventLog): void {
+    this.eventLogs.push(log);
+  }
+
   markBroadcasted(): void {
     this.lastBroadcastAt = this.elapsedTime;
   }
@@ -186,7 +190,12 @@ export class RaceSimulation {
       }
 
       let char = c;
-      if (c.status !== "running" && c.stunEndTime > 0 && this.elapsedTime >= c.stunEndTime) {
+      if (
+        c.status !== "running" &&
+        c.status !== "shielded" &&
+        c.stunEndTime > 0 &&
+        this.elapsedTime >= c.stunEndTime
+      ) {
         char = { ...c, status: "running" as const, speed: c.baseSpeed, stunEndTime: 0 };
       }
 

--- a/apps/api/src/infrastructure/durableObject/RaceRoom.ts
+++ b/apps/api/src/infrastructure/durableObject/RaceRoom.ts
@@ -193,10 +193,11 @@ export class RaceRoom extends DurableObject implements Broadcaster {
     const playerName = player?.name ?? playerId;
     const { emoji, name: effectName } = result.assignment.effect;
 
+    const snap = this.simulation.snapshot();
     this.simulation.pushEventLog({
       id: `eff_${Date.now()}`,
       text: `🎲 ${playerName}의 비밀 효과 발동! → ${emoji} ${effectName}!`,
-      timestamp: Date.now(),
+      timestamp: snap.elapsedTime,
     });
 
     const reveal: ServerMessage = {

--- a/apps/api/src/infrastructure/durableObject/RaceRoom.ts
+++ b/apps/api/src/infrastructure/durableObject/RaceRoom.ts
@@ -189,6 +189,16 @@ export class RaceRoom extends DurableObject implements Broadcaster {
     const result = this.simulation.activateEffect(playerId);
     if (!result) return;
 
+    const player = this.registry.get(playerId);
+    const playerName = player?.name ?? playerId;
+    const { emoji, name: effectName } = result.assignment.effect;
+
+    this.simulation.pushEventLog({
+      id: `eff_${Date.now()}`,
+      text: `🎲 ${playerName}의 비밀 효과 발동! → ${emoji} ${effectName}!`,
+      timestamp: Date.now(),
+    });
+
     const reveal: ServerMessage = {
       type: "effectReveal",
       playerId,

--- a/apps/api/src/presentation/http/room/room.handlers.ts
+++ b/apps/api/src/presentation/http/room/room.handlers.ts
@@ -5,22 +5,32 @@ import { generateRoomCode, getDurableObjectStub } from "../shared";
 export function createRoomHandlers() {
   return {
     async createRoom(c: Context<Env>) {
-      const code = generateRoomCode();
-      const stub = getDurableObjectStub(c.env, code);
+      const MAX_ATTEMPTS = 5;
 
-      const res = await stub.fetch(
-        new Request("https://do/init", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ roomCode: code }),
-        }),
-      );
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        const code = generateRoomCode();
+        const stub = getDurableObjectStub(c.env, code);
 
-      if (!res.ok) {
-        return c.json({ error: "Failed to create room" }, 500);
+        const stateRes = await stub.fetch(new Request("https://do/state"));
+        if (stateRes.ok) {
+          const state = (await stateRes.json()) as { players?: unknown[] };
+          if (state.players && (state.players as unknown[]).length > 0) continue;
+        }
+
+        const res = await stub.fetch(
+          new Request("https://do/init", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ roomCode: code }),
+          }),
+        );
+
+        if (!res.ok) continue;
+
+        return c.json({ roomCode: code }, 201);
       }
 
-      return c.json({ roomCode: code }, 201);
+      return c.json({ error: "Failed to create room" }, 500);
     },
 
     async getRoom(c: Context<Env>) {

--- a/apps/api/src/presentation/http/room/room.handlers.ts
+++ b/apps/api/src/presentation/http/room/room.handlers.ts
@@ -13,8 +13,10 @@ export function createRoomHandlers() {
 
         const stateRes = await stub.fetch(new Request("https://do/state"));
         if (stateRes.ok) {
-          const state = (await stateRes.json()) as { players?: unknown[] };
-          if (state.players && (state.players as unknown[]).length > 0) continue;
+          const state = (await stateRes.json()) as { players?: unknown[]; phase?: string };
+          const hasPlayers = state.players && (state.players as unknown[]).length > 0;
+          const isActive = state.phase && state.phase !== "waiting";
+          if (hasPlayers || isActive) continue;
         }
 
         const res = await stub.fetch(

--- a/apps/api/src/presentation/http/shared.ts
+++ b/apps/api/src/presentation/http/shared.ts
@@ -11,7 +11,8 @@ export function getDurableObjectStub(env: Env["Bindings"], code: string) {
 
 export function generateRoomCode(): string {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ";
-  let code = "";
+  const timePart = chars[Date.now() % chars.length];
+  let code = timePart ?? "";
   for (let i = 0; i < 4; i++) {
     code += chars[Math.floor(Math.random() * chars.length)];
   }

--- a/apps/api/src/presentation/http/shared.ts
+++ b/apps/api/src/presentation/http/shared.ts
@@ -11,10 +11,9 @@ export function getDurableObjectStub(env: Env["Bindings"], code: string) {
 
 export function generateRoomCode(): string {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ";
-  const timePart = chars[Date.now() % chars.length];
-  let code = timePart ?? "";
+  let code = chars[Date.now() % chars.length] ?? "A";
   for (let i = 0; i < 4; i++) {
-    code += chars[Math.floor(Math.random() * chars.length)];
+    code += chars[Math.floor(Math.random() * chars.length)] ?? "A";
   }
   return code;
 }

--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -105,15 +105,14 @@ export function ResultScreen() {
     return cards;
   }, [mvpMostHit, mvpLastUltimate, mvpComeback]);
 
-  const connectionStatus = useConnectionStore((s) => s.status);
   const roomCode = useConnectionStore((s) => s.roomCode);
-  const isMultiplayer = connectionStatus === "connected" && roomCode;
+  const isMultiplayer = Boolean(roomCode);
 
   const handleGoSetup = () => {
     resetGame();
     resetRouteGuardSnapshot();
     if (isMultiplayer) {
-      void navigate({ to: "/lobby", search: { code: roomCode } });
+      void navigate({ to: "/lobby", search: { code: roomCode ?? undefined } });
     } else {
       void navigate({ to: "/setup" });
     }

--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -105,10 +105,18 @@ export function ResultScreen() {
     return cards;
   }, [mvpMostHit, mvpLastUltimate, mvpComeback]);
 
+  const connectionStatus = useConnectionStore((s) => s.status);
+  const roomCode = useConnectionStore((s) => s.roomCode);
+  const isMultiplayer = connectionStatus === "connected" && roomCode;
+
   const handleGoSetup = () => {
     resetGame();
     resetRouteGuardSnapshot();
-    void navigate({ to: "/setup" });
+    if (isMultiplayer) {
+      void navigate({ to: "/lobby", search: { code: roomCode } });
+    } else {
+      void navigate({ to: "/setup" });
+    }
   };
 
   const handleGoLobby = () => {
@@ -370,9 +378,16 @@ function HiddenEffectsSection({
                 <p className="text-[0.6rem] text-white/40">{a.effect.description}</p>
               </div>
               {a.activated ? (
-                <span className="shrink-0 rounded-full bg-red-500/80 px-2 py-0.5 text-[0.6rem] font-bold text-white">
-                  발동!
-                </span>
+                <div className="flex shrink-0 flex-col items-end gap-0.5">
+                  <span className="rounded-full bg-red-500/80 px-2 py-0.5 text-[0.6rem] font-bold text-white">
+                    발동!
+                  </span>
+                  {a.activatedAt != null && (
+                    <span className="text-[0.55rem] tabular-nums text-white/50">
+                      {a.activatedAt.toFixed(1)}초에 발동
+                    </span>
+                  )}
+                </div>
               ) : (
                 <div className="flex shrink-0 flex-col items-end gap-0.5">
                   <span className="rounded-full bg-white/15 px-2 py-0.5 text-[0.6rem] font-bold text-white/60">

--- a/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
+++ b/apps/web/src/features/mountain-race/screens/ResultScreen.tsx
@@ -106,7 +106,7 @@ export function ResultScreen() {
   }, [mvpMostHit, mvpLastUltimate, mvpComeback]);
 
   const roomCode = useConnectionStore((s) => s.roomCode);
-  const isMultiplayer = Boolean(roomCode);
+  const isMultiplayer = Boolean(roomCode) || raceHiddenEffects.length > 0;
 
   const handleGoSetup = () => {
     resetGame();

--- a/packages/game-logic/src/EventSystem.ts
+++ b/packages/game-logic/src/EventSystem.ts
@@ -170,6 +170,9 @@ function applySliding(char: Character, durationMs: number, elapsedTime: number):
 }
 
 function applySetback(char: Character, amount: number): Character {
+  if (char.status === "shielded") {
+    return { ...char, status: "running" };
+  }
   const newProgress = Math.max(0, char.progress - amount);
   return {
     ...char,

--- a/packages/game-logic/src/EventSystem.ts
+++ b/packages/game-logic/src/EventSystem.ts
@@ -131,6 +131,9 @@ function replaceChar(characters: Character[], updated: Character): Character[] {
 // ── Status application ───────────────────────────────────────────────────────
 
 function applyStun(char: Character, durationMs: number, elapsedTime: number): Character {
+  if (char.status === "shielded") {
+    return { ...char, status: "running" };
+  }
   return {
     ...char,
     status: "stunned",
@@ -154,6 +157,9 @@ function applyBoost(
 }
 
 function applySliding(char: Character, durationMs: number, elapsedTime: number): Character {
+  if (char.status === "shielded") {
+    return { ...char, status: "running" };
+  }
   return {
     ...char,
     status: "sliding",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,7 +15,7 @@ export interface ColorPreset {
 
 // ── Character ──────────────────────────────────────────────────────────────
 
-export type CharacterStatus = "running" | "stunned" | "boosted" | "slowed" | "sliding";
+export type CharacterStatus = "running" | "stunned" | "boosted" | "slowed" | "sliding" | "shielded";
 
 export interface CharacterStats {
   hitCount: number;


### PR DESCRIPTION
## Addresses PR #40 Review by @YeongseoYoon

### 🔴 Critical
- [x] **Shield 효과 작동**: `"shielded"` CharacterStatus 추가, `applyStun`/`applySliding`에서 shield 소비 로직 — 1회 방해 무효화 정상 동작
- [x] **랜딩 2-step CTA**: 이미 `feat/multiplayer-base`에 정상 반영됨 (머지 후 확인)
- [x] **멀티 다시하기 라우팅**: MP 모드에서 "다시 하기" → `/lobby?code=` 이동 (로컬 설정으로 빠지지 않음)

### 🟡 Medium
- [x] **효과 발동 이벤트 로그**: `handleActivateEffect`에서 "🎲 {name}의 비밀 효과 발동!" 로그 생성
- [x] **결과 화면 발동 타이밍**: `activatedAt` 값을 "{X.X}초에 발동"으로 표시

### 🟠 Logic
- [x] **Magnet 효과**: 하드코딩된 2등 → 직접 앞 순위 플레이어로 수정
- [x] **방 코드 충돌**: 5자리 + 타임스탬프 컴포넌트, 충돌 시 최대 5회 재시도

### Remaining (별도 PR)
- [ ] 카메라 줌 + "?" 배지 3D 연출
- [ ] 얼굴 이미지 업로드
- [ ] 재접속 (rejoin)
- [ ] visibilitychange 자동 재접속
- [ ] 테스트 코드


Made with [Cursor](https://cursor.com)