### PR TITLE
feat(game-logic): connect FINISH_DIALOGUES to DialogueSystem

### DIFF
--- a/apps/api/src/domain/raceSimulation.ts
+++ b/apps/api/src/domain/raceSimulation.ts
@@ -51,6 +51,7 @@ export class RaceSimulation {
   private globalEventEndTime = 0;
   private ultimateCount = 0;
   private activeBubble: ActiveBubble | null = null;
+  private newlyFinishedIds: string[] = [];
   private lastBroadcastAt = 0;
   private lastTickWallTime = 0;
   readonly effects = new HiddenEffectManager();
@@ -202,6 +203,7 @@ export class RaceSimulation {
       .filter((c) => c.progress >= FINISH_LINE && !this.finishedIds.includes(c.id))
       .sort((a, b) => b.progress - a.progress);
     const newIds = newlyFinished.map((c) => c.id);
+    this.newlyFinishedIds = newIds;
     this.finishedIds = [...this.finishedIds, ...newIds];
 
     if (this.firstFinishTime === null && newIds.length > 0) {
@@ -246,6 +248,7 @@ export class RaceSimulation {
       characters: this.characters,
       rankings: this.rankings,
       finishedIds: this.finishedIds,
+      newlyFinishedIds: this.newlyFinishedIds,
       elapsedTime: this.elapsedTime,
       activeBubble: this.activeBubble,
       newEvents: this.events.slice(-5),

--- a/apps/api/src/domain/raceSimulation.ts
+++ b/apps/api/src/domain/raceSimulation.ts
@@ -83,6 +83,7 @@ export class RaceSimulation {
 
     this.rankings = this.characters.map((c) => c.id);
     this.finishedIds = [];
+    this.newlyFinishedIds = [];
     this.firstFinishTime = null;
     this.elapsedTime = 0;
     this.events = [];

--- a/apps/web/src/features/mountain-race/store/useGameStore.ts
+++ b/apps/web/src/features/mountain-race/store/useGameStore.ts
@@ -432,6 +432,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       characters: finalCharacters,
       rankings: computeRankings(finalCharacters),
       finishedIds,
+      newlyFinishedIds,
       elapsedTime,
       activeBubble: state.activeBubble,
       newEvents: eventResult.newEvents,

--- a/packages/game-logic/src/DialogueSystem.ts
+++ b/packages/game-logic/src/DialogueSystem.ts
@@ -396,7 +396,10 @@ function resolveDialogue(
         characters.length,
         elapsedTime,
       );
-      if (bubble) return { activeBubble: bubble };
+      if (bubble) {
+        advanceSchedule(elapsedTime);
+        return { activeBubble: bubble };
+      }
     }
   }
 

--- a/packages/game-logic/src/DialogueSystem.ts
+++ b/packages/game-logic/src/DialogueSystem.ts
@@ -18,6 +18,7 @@ import {
 import {
   CLOSE_RACE_DIALOGUES,
   COMEBACK_DIALOGUES,
+  FINISH_DIALOGUES,
   FIRST_PLACE_DIALOGUES,
   GLOBAL_EVENT_DIALOGUES,
   IDLE_DIALOGUES,
@@ -37,6 +38,7 @@ export interface DialogueTickInput {
   characters: Character[];
   rankings: string[];
   finishedIds: string[];
+  newlyFinishedIds: string[];
   elapsedTime: number;
   activeBubble: ActiveBubble | null;
   newEvents: GameEvent[];
@@ -333,12 +335,21 @@ export function resetDialogueScheduler(): void {
 }
 
 export function processDialogues(input: DialogueTickInput): DialogueTickResult {
-  const { characters, rankings, finishedIds, elapsedTime, activeBubble, newEvents } = input;
+  const {
+    characters,
+    rankings,
+    finishedIds,
+    newlyFinishedIds,
+    elapsedTime,
+    activeBubble,
+    newEvents,
+  } = input;
 
   const result = resolveDialogue(
     characters,
     rankings,
     finishedIds,
+    newlyFinishedIds,
     elapsedTime,
     activeBubble,
     newEvents,
@@ -347,14 +358,48 @@ export function processDialogues(input: DialogueTickInput): DialogueTickResult {
   return result;
 }
 
+function pickFinishDialogue(
+  characterId: string,
+  finishRank: number,
+  totalCharacters: number,
+  elapsedTime: number,
+): ActiveBubble | null {
+  let key: string;
+  if (finishRank === 0) key = "first";
+  else if (finishRank === 1) key = "second";
+  else if (finishRank === 2) key = "third";
+  else if (finishRank === totalCharacters - 1) key = "last";
+  else key = "rest";
+
+  const pool = FINISH_DIALOGUES[key];
+  if (!pool || pool.length === 0) return null;
+  return makeBubble(characterId, pickRandom(pool), elapsedTime);
+}
+
 function resolveDialogue(
   characters: readonly Character[],
   rankings: string[],
   finishedIds: string[],
+  newlyFinishedIds: readonly string[],
   elapsedTime: number,
   activeBubble: ActiveBubble | null,
   newEvents: readonly GameEvent[],
 ): DialogueTickResult {
+  // 0. Finish dialogue — highest priority, fires once per finisher
+  if (newlyFinishedIds.length > 0) {
+    const firstFinisher = newlyFinishedIds[0];
+    if (firstFinisher !== undefined) {
+      const finishRank = finishedIds.indexOf(firstFinisher);
+      const bubble = pickFinishDialogue(
+        firstFinisher,
+        finishRank === -1 ? finishedIds.length : finishRank,
+        characters.length,
+        elapsedTime,
+      );
+      if (bubble) return { activeBubble: bubble };
+    }
+  }
+
   // 1. Try event dialogue first (may override existing bubble for high-priority)
   if (newEvents.length > 0) {
     const hasHighPriority = newEvents.some(


### PR DESCRIPTION
## 요약

캐릭터 완주 시 순위별 대사가 출력되지 않던 문제를 해결합니다. 기존에 정의만 되어 있던 `FINISH_DIALOGUES` 데이터를 `DialogueSystem`에 연결하여 결승선 통과 시 순위에 맞는 대사가 말풍선으로 표시됩니다.

## 변경 사항

- `DialogueTickInput`에 `newlyFinishedIds: string[]` 필드 추가
- `pickFinishDialogue()` 함수 신규 — 완주 순위(first / second / third / rest / last)에 따라 대사 선택
- `resolveDialogue()` 최상단에 완주 대사 로직 추가 (이벤트 대사보다 높은 우선순위)
- `useGameStore.ts`의 `processDialogues` 호출에 `newlyFinishedIds` 전달
- `raceSimulation.ts`의 `detectFinishers()`에서 매 tick 새로 완주한 ID를 기록하고 `runDialogueSystem()`에서 전달

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `docs`
- [ ] `.cursor`
- [ ] CI / 배포 / 루트 설정

## 검증

- 실행한 명령:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm check` (pre-push hook으로 lint + format:check + typecheck + build 전체 통과)
  - [ ] 기타:
- 수동 확인: 없음 — 로컬에서 레이스를 돌려 완주 대사 표시를 직접 확인하지는 않았습니다
- 실행하지 않은 검증과 이유: 브라우저에서 레이스 완주까지의 수동 플레이 테스트는 미실행. CI 통과 후 확인 필요.

## 스크린샷 또는 데모

UI 변경 없음. 기존 `SpeechBubble` 컴포넌트를 통해 대사가 표시되므로 시각적 변화는 대사 텍스트 내용에 한정됩니다.

## 문서 반영

- [x] 문서 변경 없음
- 관련 문서: `docs/mountain-race-technical-prd.md`의 finish dialogue 항목이 이 PR로 해소됨

## 리스크와 후속 작업

- `FINISH_DIALOGUES`의 각 key에 대사가 1개뿐이므로 다양성이 부족할 수 있음. 추후 대사 풀 확장 검토.
- 같은 tick에 여러 캐릭터가 동시 완주하면 첫 번째 완주자의 대사만 출력됨. 연속 완주 시 후속 완주자 대사는 다음 스케줄에서 자연스럽게 처리될 수 있으나, 의도적 연출이 필요하면 별도 작업 필요.

Made with [Cursor](https://cursor.com)